### PR TITLE
[codex] align Bun publish flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '21'
       - name: Build
         id: build_code
-        run: npm run verify:android
+        run: bun run verify:android
   build_ios:
     timeout-minutes: 30
     runs-on: macOS-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,46 +7,38 @@ This guide provides instructions for contributing to this Capacitor plugin.
 ### Local Setup
 
 1. Fork and clone the repo.
-1. Install the dependencies.
+2. Install dependencies.
 
-    ```shell
-    npm install
-    ```
+```shell
+bun install
+```
 
-1. Install SwiftLint if you're on macOS.
+3. Install SwiftLint if you're on macOS.
 
-    ```shell
-    brew install swiftlint
-    ```
+```shell
+brew install swiftlint
+```
 
 ### Scripts
 
-#### `npm run build`
+#### `bun run build`
 
-Build the plugin web assets and generate plugin API documentation using [`@capacitor/docgen`](https://github.com/ionic-team/capacitor-docgen).
+Builds plugin web assets and generates API documentation with [`@capacitor/docgen`](https://github.com/ionic-team/capacitor-docgen).
 
-It will compile the TypeScript code from `src/` into ESM JavaScript in `dist/esm/`. These files are used in apps with bundlers when your plugin is imported.
+#### `bun run verify`
 
-Then, Rollup will bundle the code into a single file at `dist/plugin.js`. This file is used in apps without bundlers by including it as a script in `index.html`.
+Builds and validates iOS, Android, and Web.
 
-#### `npm run verify`
+#### `bun run lint` / `bun run fmt`
 
-Build and validate the web and native projects.
-
-This is useful to run in CI to verify that the plugin builds for all platforms.
-
-#### `npm run lint` / `npm run fmt`
-
-Check formatting and code quality, autoformat/autofix if possible.
-
-This template is integrated with ESLint, Prettier, and SwiftLint. Using these tools is completely optional, but the [Capacitor Community](https://github.com/capacitor-community/) strives to have consistent code style and structure for easier cooperation.
+Checks or auto-fixes formatting and linting.
 
 ## Publishing
 
-There is a `prepublishOnly` hook in `package.json` which prepares the plugin before publishing, so all you need to do is run:
+The `prepublishOnly` hook prepares the plugin before publishing.
 
 ```shell
-npm publish
+bun publish
 ```
 
-> **Note**: The [`files`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files) array in `package.json` specifies which files get published. If you rename files/directories or add files elsewhere, you may need to update it.
+> The `files` array in `package.json` controls what is published. Update it if you move files.

--- a/package.json
+++ b/package.json
@@ -47,20 +47,20 @@
     "gps"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
+    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
     "verify:ios": "xcodebuild -scheme CapgoCapacitorLaunchNavigator -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "npm run build",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
-    "eslint": "eslint . --ext ts",
+    "verify:web": "bun run build",
+    "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",
+    "fmt": "bun run eslint -- --fix && bun run prettier -- --write && bun run swiftlint -- --fix --format",
+    "eslint": "eslint . --ext .ts",
     "prettier": "prettier-pretty-check \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api LaunchNavigatorPlugin --output-readme README.md --output-json dist/docs.json",
-    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
+    "build": "bun run clean && bun run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed
- switched plugin package scripts from `npm run` to `bun run` for verify, lint, build, and prepublish
- updated contributor docs to use `bun install` and `bun publish`
- aligned Android CI to call `bun run verify:android`

## Why
This plugin was still using the older npm-based command path while the current Capgo plugin workflow uses Bun for local publish/build steps.

## Impact
The plugin now matches the current template and repo conventions for publish-related commands, reducing drift between local docs, package scripts, and CI.

## Root cause
`capacitor-launch-navigator` had not been updated when the shared plugin workflow moved from npm-oriented commands to Bun-oriented commands.

## Validation
- `bun run check:wiring`
- `bun run build`
- `bun run lint`
- `bun run verify:android`
- `bun run verify:ios`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build and task automation now uses Bun instead of npm in CI workflows and package configuration.

* **Documentation**
  * Updated contribution guidelines to reference Bun for dependency installation, publishing, and running development scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->