### PR TITLE
[codex] add navigation app support

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ Add URL schemes to your `Info.plist` to detect installed navigation apps:
     <string>moovit</string>
     <string>lyft</string>
     <string>mapsme</string>
+    <string>guru</string>
+    <string>om</string>
+    <string>yandexmaps</string>
+    <string>dgis</string>
     <string>cabify</string>
     <string>baidumap</string>
     <string>iosamap</string>
+    <string>tesla</string>
     <string>99app</string>
 </array>
 ```
@@ -82,9 +87,17 @@ The following navigation apps are declared in the plugin's manifest:
     <package android:name="com.tranzmate" />
     <package android:name="me.lyft.android" />
     <package android:name="com.mapswithme.maps.pro" />
+    <package android:name="com.tomtom.gplay.navapp" />
+    <package android:name="com.bodunov.galileo" />
+    <package android:name="com.bodunov.GalileoPro" />
+    <package android:name="app.organicmaps" />
+    <package android:name="ru.yandex.yandexmaps" />
+    <package android:name="cz.seznam.mapy" />
+    <package android:name="ru.dublgis.dgismobile" />
     <package android:name="com.cabify.rider" />
     <package android:name="com.baidu.BaiduMap" />
     <package android:name="com.autonavi.minimap" />
+    <package android:name="com.teslamotors.tesla" />
 </queries>
 ```
 
@@ -126,12 +139,32 @@ const { apps } = await LaunchNavigator.getAvailableApps();
 apps.forEach(app => {
     console.log(`${app.name} is ${app.available ? 'available' : 'not installed'}`);
 });
+
+// Fetch local provider icons for display
+const { icons, failures } = await LaunchNavigator.getAppIcons({
+    apps: ['google_maps', 'waze']
+});
+
+icons.forEach(icon => {
+    const image = document.querySelector<HTMLImageElement>(`img[data-app="${icon.app}"]`);
+    if (image) {
+        image.src = icon.localUrl; // Uses the local cache after the first fetch
+    }
+});
+
+// Force a refresh when an icon needs to be repaired
+await LaunchNavigator.refreshAppIcons({
+    apps: ['waze']
+});
+
+console.log('Icon failures:', failures);
 ```
 
 ## Important Notes
 
 - **Coordinates Only**: This plugin only accepts latitude/longitude coordinates for navigation. Address strings are not supported.
 - **Address Geocoding**: If you need to convert addresses to coordinates, use [@capgo/capacitor-nativegeocoder](https://github.com/Cap-go/capacitor-nativegeocoder).
+- **Tesla**: `app: 'tesla'` shares a Google Maps directions link to the Tesla app. Android targets the Tesla app directly; iOS opens the native share sheet because iOS does not allow selecting another app's share extension programmatically.
 
 ## Supported Navigation Apps
 
@@ -150,9 +183,14 @@ apps.forEach(app => {
 - Moovit
 - Lyft
 - MAPS.ME
+- Guru Maps
+- Organic Maps
+- Yandex Maps
+- 2GIS
 - Cabify
 - Baidu Maps
 - Gaode Maps
+- Tesla
 - 99 Taxi
 
 ### Android
@@ -166,9 +204,16 @@ apps.forEach(app => {
 - Moovit
 - Lyft
 - MAPS.ME
+- TomTom GO
+- Guru Maps
+- Organic Maps
+- Yandex Maps
+- Mapy.com
+- 2GIS
 - Cabify
 - Baidu Maps
 - Gaode Maps
+- Tesla
 
 ## API
 
@@ -179,6 +224,9 @@ apps.forEach(app => {
 * [`getAvailableApps()`](#getavailableapps)
 * [`getSupportedApps()`](#getsupportedapps)
 * [`getDefaultApp()`](#getdefaultapp)
+* [`getAppIcons(...)`](#getappicons)
+* [`refreshAppIcons(...)`](#refreshappicons)
+* [`clearIconCache(...)`](#cleariconcache)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -262,6 +310,60 @@ Get the name of the default app for navigation
 --------------------
 
 
+### getAppIcons(...)
+
+```typescript
+getAppIcons(options?: GetAppIconsOptions | undefined) => Promise<ProviderIconsResult>
+```
+
+Fetch provider icons and cache them locally.
+
+The native implementations revalidate cached icons after 24 hours by default.
+Pass `forceRefresh: true` to bypass the cache when an icon must be repaired.
+
+| Param         | Type                                                              |
+| ------------- | ----------------------------------------------------------------- |
+| **`options`** | <code><a href="#getappiconsoptions">GetAppIconsOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#providericonsresult">ProviderIconsResult</a>&gt;</code>
+
+--------------------
+
+
+### refreshAppIcons(...)
+
+```typescript
+refreshAppIcons(options?: GetAppIconsOptions | undefined) => Promise<ProviderIconsResult>
+```
+
+Refresh provider icons, ignoring the cache age.
+
+| Param         | Type                                                              |
+| ------------- | ----------------------------------------------------------------- |
+| **`options`** | <code><a href="#getappiconsoptions">GetAppIconsOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#providericonsresult">ProviderIconsResult</a>&gt;</code>
+
+--------------------
+
+
+### clearIconCache(...)
+
+```typescript
+clearIconCache(options?: ClearIconCacheOptions | undefined) => Promise<{ cleared: number; }>
+```
+
+Clear cached provider icons.
+
+| Param         | Type                                                                    |
+| ------------- | ----------------------------------------------------------------------- |
+| **`options`** | <code><a href="#cleariconcacheoptions">ClearIconCacheOptions</a></code> |
+
+**Returns:** <code>Promise&lt;{ cleared: number; }&gt;</code>
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -305,6 +407,77 @@ Result of checking app availability
 | **`available`** | <code>boolean</code> | Whether the app is available on the device |
 
 
+#### ProviderIconsResult
+
+Result of fetching provider icons.
+
+| Prop           | Type                               | Description                                                    |
+| -------------- | ---------------------------------- | -------------------------------------------------------------- |
+| **`icons`**    | <code>ProviderIcon[]</code>        | Icons available from cache or freshly downloaded               |
+| **`failures`** | <code>ProviderIconFailure[]</code> | Providers that could not be fetched and had no cached fallback |
+
+
+#### ProviderIcon
+
+Cached icon for a navigation provider.
+
+| Prop            | Type                 | Description                                                           |
+| --------------- | -------------------- | --------------------------------------------------------------------- |
+| **`app`**       | <code>string</code>  | Navigation app identifier                                             |
+| **`name`**      | <code>string</code>  | Display name for the provider                                         |
+| **`localUrl`**  | <code>string</code>  | URL that can be used directly in an image element inside the WebView. |
+| **`sourceUrl`** | <code>string</code>  | Web URL used to download the cached image                             |
+| **`mimeType`**  | <code>string</code>  | MIME type reported for the cached image, when known                   |
+| **`fetchedAt`** | <code>number</code>  | Unix timestamp in milliseconds when the icon was last fetched         |
+| **`fromCache`** | <code>boolean</code> | Whether the icon came from the local cache without a network refresh  |
+| **`stale`**     | <code>boolean</code> | Whether a stale cached icon was returned because refresh failed       |
+
+
+#### ProviderIconFailure
+
+Icon fetch failure for a provider.
+
+| Prop            | Type                | Description                     |
+| --------------- | ------------------- | ------------------------------- |
+| **`app`**       | <code>string</code> | Navigation app identifier       |
+| **`name`**      | <code>string</code> | Display name for the provider   |
+| **`sourceUrl`** | <code>string</code> | Web URL that failed, when known |
+| **`message`**   | <code>string</code> | Failure message                 |
+
+
+#### GetAppIconsOptions
+
+Options for fetching navigation provider icons.
+
+| Prop               | Type                        | Description                                                                            |
+| ------------------ | --------------------------- | -------------------------------------------------------------------------------------- |
+| **`apps`**         | <code>string[]</code>       | App identifiers to fetch. Defaults to all built-in providers for the current platform. |
+| **`providers`**    | <code>IconProvider[]</code> | Provider definitions to fetch or override built-in provider websites.                  |
+| **`maxAgeMs`**     | <code>number</code>         | Cache revalidation interval in milliseconds. Defaults to 24 hours.                     |
+| **`forceRefresh`** | <code>boolean</code>        | Ignore the current cache and fetch icons again.                                        |
+
+
+#### IconProvider
+
+Web source used to discover or download a provider icon.
+
+| Prop          | Type                | Description                                                                                                 |
+| ------------- | ------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **`app`**     | <code>string</code> | Navigation app identifier                                                                                   |
+| **`name`**    | <code>string</code> | Display name for the provider                                                                               |
+| **`url`**     | <code>string</code> | Provider website used to discover favicon metadata                                                          |
+| **`iconUrl`** | <code>string</code> | Direct image URL. When provided, the plugin downloads this URL instead of discovering a favicon from `url`. |
+
+
+#### ClearIconCacheOptions
+
+Options for clearing cached provider icons.
+
+| Prop       | Type                  | Description                                             |
+| ---------- | --------------------- | ------------------------------------------------------- |
+| **`apps`** | <code>string[]</code> | App identifiers to clear. Defaults to all cached icons. |
+
+
 ### Type Aliases
 
 
@@ -346,29 +519,41 @@ Construct a type with a set of properties K of type T
 | **`MOOVIT`**           | <code>'moovit'</code>         |
 | **`LYFT`**             | <code>'lyft'</code>           |
 | **`MAPS_ME`**          | <code>'mapsme'</code>         |
+| **`GURU_MAPS`**        | <code>'guru_maps'</code>      |
+| **`ORGANIC_MAPS`**     | <code>'organic_maps'</code>   |
+| **`YANDEX_MAPS`**      | <code>'yandex_maps'</code>    |
+| **`TWO_GIS`**          | <code>'2gis'</code>           |
 | **`CABIFY`**           | <code>'cabify'</code>         |
 | **`BAIDU`**            | <code>'baidu'</code>          |
 | **`GAODE`**            | <code>'gaode'</code>          |
+| **`TESLA`**            | <code>'tesla'</code>          |
 | **`TAXI_99`**          | <code>'99taxi'</code>         |
 
 
 #### AndroidNavigationApp
 
-| Members           | Value                      |
-| ----------------- | -------------------------- |
-| **`GOOGLE_MAPS`** | <code>'google_maps'</code> |
-| **`WAZE`**        | <code>'waze'</code>        |
-| **`CITYMAPPER`**  | <code>'citymapper'</code>  |
-| **`UBER`**        | <code>'uber'</code>        |
-| **`YANDEX`**      | <code>'yandex'</code>      |
-| **`SYGIC`**       | <code>'sygic'</code>       |
-| **`HERE_MAPS`**   | <code>'here'</code>        |
-| **`MOOVIT`**      | <code>'moovit'</code>      |
-| **`LYFT`**        | <code>'lyft'</code>        |
-| **`MAPS_ME`**     | <code>'mapsme'</code>      |
-| **`CABIFY`**      | <code>'cabify'</code>      |
-| **`BAIDU`**       | <code>'baidu'</code>       |
-| **`GAODE`**       | <code>'gaode'</code>       |
+| Members            | Value                       |
+| ------------------ | --------------------------- |
+| **`GOOGLE_MAPS`**  | <code>'google_maps'</code>  |
+| **`WAZE`**         | <code>'waze'</code>         |
+| **`CITYMAPPER`**   | <code>'citymapper'</code>   |
+| **`UBER`**         | <code>'uber'</code>         |
+| **`YANDEX`**       | <code>'yandex'</code>       |
+| **`SYGIC`**        | <code>'sygic'</code>        |
+| **`HERE_MAPS`**    | <code>'here'</code>         |
+| **`MOOVIT`**       | <code>'moovit'</code>       |
+| **`LYFT`**         | <code>'lyft'</code>         |
+| **`MAPS_ME`**      | <code>'mapsme'</code>       |
+| **`TOMTOM`**       | <code>'tomtom'</code>       |
+| **`GURU_MAPS`**    | <code>'guru_maps'</code>    |
+| **`ORGANIC_MAPS`** | <code>'organic_maps'</code> |
+| **`YANDEX_MAPS`**  | <code>'yandex_maps'</code>  |
+| **`MAPY`**         | <code>'mapy'</code>         |
+| **`TWO_GIS`**      | <code>'2gis'</code>         |
+| **`CABIFY`**       | <code>'cabify'</code>       |
+| **`BAIDU`**        | <code>'baidu'</code>        |
+| **`GAODE`**        | <code>'gaode'</code>        |
+| **`TESLA`**        | <code>'tesla'</code>        |
 
 
 #### LaunchMode

--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ Add URL schemes to your `Info.plist` to detect installed navigation apps:
     <string>moovit</string>
     <string>lyft</string>
     <string>mapsme</string>
+    <string>guru</string>
+    <string>om</string>
+    <string>yandexmaps</string>
+    <string>dgis</string>
     <string>cabify</string>
     <string>baidumap</string>
     <string>iosamap</string>
+    <string>tesla</string>
     <string>99app</string>
 </array>
 ```
@@ -82,9 +87,17 @@ The following navigation apps are declared in the plugin's manifest:
     <package android:name="com.tranzmate" />
     <package android:name="me.lyft.android" />
     <package android:name="com.mapswithme.maps.pro" />
+    <package android:name="com.tomtom.gplay.navapp" />
+    <package android:name="com.bodunov.galileo" />
+    <package android:name="com.bodunov.GalileoPro" />
+    <package android:name="app.organicmaps" />
+    <package android:name="ru.yandex.yandexmaps" />
+    <package android:name="cz.seznam.mapy" />
+    <package android:name="ru.dublgis.dgismobile" />
     <package android:name="com.cabify.rider" />
     <package android:name="com.baidu.BaiduMap" />
     <package android:name="com.autonavi.minimap" />
+    <package android:name="com.teslamotors.tesla" />
 </queries>
 ```
 
@@ -116,6 +129,15 @@ await LaunchNavigator.navigate({
     }
 });
 
+// Share a Google Maps directions link to the Tesla app
+await LaunchNavigator.navigate({
+    destination: [37.7749, -122.4194],
+    options: {
+        app: 'tesla',
+        transportMode: TransportMode.DRIVING
+    }
+});
+
 // Check if an app is available
 const { available } = await LaunchNavigator.isAppAvailable({
     app: IOSNavigationApp.GOOGLE_MAPS
@@ -132,6 +154,7 @@ apps.forEach(app => {
 
 - **Coordinates Only**: This plugin only accepts latitude/longitude coordinates for navigation. Address strings are not supported.
 - **Address Geocoding**: If you need to convert addresses to coordinates, use [@capgo/capacitor-nativegeocoder](https://github.com/Cap-go/capacitor-nativegeocoder).
+- **Tesla**: Android shares a Google Maps directions URL directly to the Tesla app. iOS opens the native share sheet with the same Google Maps URL so users can pick Tesla.
 
 ## Supported Navigation Apps
 
@@ -150,9 +173,14 @@ apps.forEach(app => {
 - Moovit
 - Lyft
 - MAPS.ME
+- Guru Maps
+- Organic Maps
+- Yandex Maps
+- 2GIS
 - Cabify
 - Baidu Maps
 - Gaode Maps
+- Tesla
 - 99 Taxi
 
 ### Android
@@ -166,9 +194,16 @@ apps.forEach(app => {
 - Moovit
 - Lyft
 - MAPS.ME
+- TomTom GO
+- Guru Maps
+- Organic Maps
+- Yandex Maps
+- Mapy.com
+- 2GIS
 - Cabify
 - Baidu Maps
 - Gaode Maps
+- Tesla
 
 ## API
 
@@ -346,29 +381,41 @@ Construct a type with a set of properties K of type T
 | **`MOOVIT`**           | <code>'moovit'</code>         |
 | **`LYFT`**             | <code>'lyft'</code>           |
 | **`MAPS_ME`**          | <code>'mapsme'</code>         |
+| **`GURU_MAPS`**        | <code>'guru_maps'</code>      |
+| **`ORGANIC_MAPS`**     | <code>'organic_maps'</code>   |
+| **`YANDEX_MAPS`**      | <code>'yandex_maps'</code>    |
+| **`TWO_GIS`**          | <code>'2gis'</code>           |
 | **`CABIFY`**           | <code>'cabify'</code>         |
 | **`BAIDU`**            | <code>'baidu'</code>          |
 | **`GAODE`**            | <code>'gaode'</code>          |
+| **`TESLA`**            | <code>'tesla'</code>          |
 | **`TAXI_99`**          | <code>'99taxi'</code>         |
 
 
 #### AndroidNavigationApp
 
-| Members           | Value                      |
-| ----------------- | -------------------------- |
-| **`GOOGLE_MAPS`** | <code>'google_maps'</code> |
-| **`WAZE`**        | <code>'waze'</code>        |
-| **`CITYMAPPER`**  | <code>'citymapper'</code>  |
-| **`UBER`**        | <code>'uber'</code>        |
-| **`YANDEX`**      | <code>'yandex'</code>      |
-| **`SYGIC`**       | <code>'sygic'</code>       |
-| **`HERE_MAPS`**   | <code>'here'</code>        |
-| **`MOOVIT`**      | <code>'moovit'</code>      |
-| **`LYFT`**        | <code>'lyft'</code>        |
-| **`MAPS_ME`**     | <code>'mapsme'</code>      |
-| **`CABIFY`**      | <code>'cabify'</code>      |
-| **`BAIDU`**       | <code>'baidu'</code>       |
-| **`GAODE`**       | <code>'gaode'</code>       |
+| Members            | Value                       |
+| ------------------ | --------------------------- |
+| **`GOOGLE_MAPS`**  | <code>'google_maps'</code>  |
+| **`WAZE`**         | <code>'waze'</code>         |
+| **`CITYMAPPER`**   | <code>'citymapper'</code>   |
+| **`UBER`**         | <code>'uber'</code>         |
+| **`YANDEX`**       | <code>'yandex'</code>       |
+| **`SYGIC`**        | <code>'sygic'</code>        |
+| **`HERE_MAPS`**    | <code>'here'</code>         |
+| **`MOOVIT`**       | <code>'moovit'</code>       |
+| **`LYFT`**         | <code>'lyft'</code>         |
+| **`MAPS_ME`**      | <code>'mapsme'</code>       |
+| **`TOMTOM`**       | <code>'tomtom'</code>       |
+| **`GURU_MAPS`**    | <code>'guru_maps'</code>    |
+| **`ORGANIC_MAPS`** | <code>'organic_maps'</code> |
+| **`YANDEX_MAPS`**  | <code>'yandex_maps'</code>  |
+| **`MAPY`**         | <code>'mapy'</code>         |
+| **`TWO_GIS`**      | <code>'2gis'</code>         |
+| **`CABIFY`**       | <code>'cabify'</code>       |
+| **`BAIDU`**        | <code>'baidu'</code>        |
+| **`GAODE`**        | <code>'gaode'</code>        |
+| **`TESLA`**        | <code>'tesla'</code>        |
 
 
 #### LaunchMode

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <queries>
         <package android:name="com.google.android.apps.maps" />
         <package android:name="com.waze" />
@@ -10,8 +12,16 @@
         <package android:name="com.tranzmate" />
         <package android:name="me.lyft.android" />
         <package android:name="com.mapswithme.maps.pro" />
+        <package android:name="com.tomtom.gplay.navapp" />
+        <package android:name="com.bodunov.galileo" />
+        <package android:name="com.bodunov.GalileoPro" />
+        <package android:name="app.organicmaps" />
+        <package android:name="ru.yandex.yandexmaps" />
+        <package android:name="cz.seznam.mapy" />
+        <package android:name="ru.dublgis.dgismobile" />
         <package android:name="com.cabify.rider" />
         <package android:name="com.baidu.BaiduMap" />
         <package android:name="com.autonavi.minimap" />
+        <package android:name="com.teslamotors.tesla" />
     </queries>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -10,8 +10,16 @@
         <package android:name="com.tranzmate" />
         <package android:name="me.lyft.android" />
         <package android:name="com.mapswithme.maps.pro" />
+        <package android:name="com.tomtom.gplay.navapp" />
+        <package android:name="com.bodunov.galileo" />
+        <package android:name="com.bodunov.GalileoPro" />
+        <package android:name="app.organicmaps" />
+        <package android:name="ru.yandex.yandexmaps" />
+        <package android:name="cz.seznam.mapy" />
+        <package android:name="ru.dublgis.dgismobile" />
         <package android:name="com.cabify.rider" />
         <package android:name="com.baidu.BaiduMap" />
         <package android:name="com.autonavi.minimap" />
+        <package android:name="com.teslamotors.tesla" />
     </queries>
 </manifest>

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
@@ -6,7 +6,7 @@ import android.content.pm.PackageManager;
 import android.net.Uri;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -18,11 +18,11 @@ public class LaunchNavigator {
     private static class AppInfo {
 
         String name;
-        String packageName;
+        String[] packageNames;
 
-        AppInfo(String name, String packageName) {
+        AppInfo(String name, String... packageNames) {
             this.name = name;
-            this.packageName = packageName;
+            this.packageNames = packageNames;
         }
     }
 
@@ -32,7 +32,7 @@ public class LaunchNavigator {
     }
 
     private void initializeApps() {
-        navigationApps = new HashMap<>();
+        navigationApps = new LinkedHashMap<>();
         navigationApps.put("google_maps", new AppInfo("Google Maps", "com.google.android.apps.maps"));
         navigationApps.put("waze", new AppInfo("Waze", "com.waze"));
         navigationApps.put("citymapper", new AppInfo("Citymapper", "com.citymapper.app.release"));
@@ -43,9 +43,16 @@ public class LaunchNavigator {
         navigationApps.put("moovit", new AppInfo("Moovit", "com.tranzmate"));
         navigationApps.put("lyft", new AppInfo("Lyft", "me.lyft.android"));
         navigationApps.put("mapsme", new AppInfo("MAPS.ME", "com.mapswithme.maps.pro"));
+        navigationApps.put("tomtom", new AppInfo("TomTom GO", "com.tomtom.gplay.navapp"));
+        navigationApps.put("guru_maps", new AppInfo("Guru Maps", "com.bodunov.galileo", "com.bodunov.GalileoPro"));
+        navigationApps.put("organic_maps", new AppInfo("Organic Maps", "app.organicmaps"));
+        navigationApps.put("yandex_maps", new AppInfo("Yandex Maps", "ru.yandex.yandexmaps"));
+        navigationApps.put("mapy", new AppInfo("Mapy.com", "cz.seznam.mapy"));
+        navigationApps.put("2gis", new AppInfo("2GIS", "ru.dublgis.dgismobile"));
         navigationApps.put("cabify", new AppInfo("Cabify", "com.cabify.rider"));
         navigationApps.put("baidu", new AppInfo("Baidu Maps", "com.baidu.BaiduMap"));
         navigationApps.put("gaode", new AppInfo("Gaode Maps", "com.autonavi.minimap"));
+        navigationApps.put("tesla", new AppInfo("Tesla", "com.teslamotors.tesla"));
     }
 
     public boolean navigate(
@@ -59,53 +66,9 @@ public class LaunchNavigator {
         String transportMode
     ) {
         try {
-            Intent intent;
+            Intent intent = createNavigationIntent(app, lat, lon, startLat, startLon, destinationName, transportMode);
 
-            switch (app) {
-                case "google_maps":
-                    intent = createGoogleMapsIntent(lat, lon, startLat, startLon, transportMode);
-                    break;
-                case "waze":
-                    intent = createWazeIntent(lat, lon);
-                    break;
-                case "citymapper":
-                    intent = createCitymapperIntent(lat, lon, startLat, startLon);
-                    break;
-                case "uber":
-                    intent = createUberIntent(lat, lon, startLat, startLon);
-                    break;
-                case "yandex":
-                    intent = createYandexIntent(lat, lon, startLat, startLon);
-                    break;
-                case "sygic":
-                    intent = createSygicIntent(lat, lon);
-                    break;
-                case "here":
-                    intent = createHereIntent(lat, lon, startLat, startLon);
-                    break;
-                case "moovit":
-                    intent = createMoovitIntent(lat, lon, startLat, startLon);
-                    break;
-                case "lyft":
-                    intent = createLyftIntent(lat, lon);
-                    break;
-                case "mapsme":
-                    intent = createMapsMeIntent(lat, lon);
-                    break;
-                case "cabify":
-                    intent = createCabifyIntent(lat, lon, startLat, startLon);
-                    break;
-                case "baidu":
-                    intent = createBaiduIntent(lat, lon, startLat, startLon);
-                    break;
-                case "gaode":
-                    intent = createGaodeIntent(lat, lon, startLat, startLon);
-                    break;
-                default:
-                    return false;
-            }
-
-            if (intent != null) {
+            if (intent != null && canHandleIntent(intent)) {
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 context.startActivity(intent);
                 return true;
@@ -115,6 +78,61 @@ public class LaunchNavigator {
         } catch (Exception e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    private Intent createNavigationIntent(
+        String app,
+        double lat,
+        double lon,
+        Double startLat,
+        Double startLon,
+        String destinationName,
+        String transportMode
+    ) {
+        switch (app) {
+            case "google_maps":
+                return createGoogleMapsIntent(lat, lon, startLat, startLon, transportMode);
+            case "waze":
+                return createWazeIntent(lat, lon);
+            case "citymapper":
+                return createCitymapperIntent(lat, lon, startLat, startLon);
+            case "uber":
+                return createUberIntent(lat, lon, startLat, startLon);
+            case "yandex":
+                return createYandexIntent(lat, lon, startLat, startLon);
+            case "sygic":
+                return createSygicIntent(lat, lon);
+            case "here":
+                return createHereIntent(lat, lon, startLat, startLon);
+            case "moovit":
+                return createMoovitIntent(lat, lon, startLat, startLon);
+            case "lyft":
+                return createLyftIntent(lat, lon);
+            case "mapsme":
+                return createMapsMeIntent(lat, lon);
+            case "tomtom":
+                return createTomTomIntent(lat, lon);
+            case "guru_maps":
+                return createGuruMapsIntent(lat, lon, startLat, startLon, transportMode);
+            case "organic_maps":
+                return createOrganicMapsIntent(lat, lon, startLat, startLon, destinationName, transportMode);
+            case "yandex_maps":
+                return createYandexMapsIntent(lat, lon, startLat, startLon);
+            case "mapy":
+                return createMapyIntent(lat, lon);
+            case "2gis":
+                return create2GisIntent(lat, lon, startLat, startLon, transportMode);
+            case "cabify":
+                return createCabifyIntent(lat, lon, startLat, startLon);
+            case "baidu":
+                return createBaiduIntent(lat, lon, startLat, startLon);
+            case "gaode":
+                return createGaodeIntent(lat, lon, startLat, startLon);
+            case "tesla":
+                return createTeslaIntent(lat, lon, startLat, startLon, transportMode);
+            default:
+                return null;
         }
     }
 
@@ -230,6 +248,130 @@ public class LaunchNavigator {
         return new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
     }
 
+    private Intent createTomTomIntent(double lat, double lon) {
+        String uri = String.format(Locale.US, "tomtomgo://x-callback-url/navigate?destination=%f,%f", lat, lon);
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("com.tomtom.gplay.navapp");
+        return intent;
+    }
+
+    private Intent createGuruMapsIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        String uri = String.format(
+            Locale.US,
+            "guru://nav?finish=%f,%f&mode=%s&start_navigation=true",
+            lat,
+            lon,
+            getGuruMapsMode(transportMode)
+        );
+        if (startLat != null && startLon != null) {
+            uri += String.format(Locale.US, "&start=%f,%f", startLat, startLon);
+        }
+
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        String packageName = getFirstInstalledPackage("guru_maps");
+        if (packageName != null) {
+            intent.setPackage(packageName);
+        }
+        return intent;
+    }
+
+    private String getGuruMapsMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "pedestrian";
+            case "bicycling":
+                return "bicycle";
+            case "driving":
+            case "transit":
+            default:
+                return "auto";
+        }
+    }
+
+    private Intent createOrganicMapsIntent(
+        double lat,
+        double lon,
+        Double startLat,
+        Double startLon,
+        String destinationName,
+        String transportMode
+    ) {
+        String origin = "currentLocation";
+        if (startLat != null && startLon != null) {
+            origin = String.format(Locale.US, "%f,%f", startLat, startLon);
+        }
+
+        String uri = String.format(
+            Locale.US,
+            "om://v2/nav?origin=%s&destination=%f,%f&mode=%s",
+            Uri.encode(origin),
+            lat,
+            lon,
+            getOrganicMapsMode(transportMode)
+        );
+        if (destinationName != null && !destinationName.isEmpty()) {
+            uri += "&destination_name=" + Uri.encode(destinationName);
+        }
+
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("app.organicmaps");
+        return intent;
+    }
+
+    private String getOrganicMapsMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "pedestrian";
+            case "bicycling":
+                return "bicycle";
+            case "transit":
+                return "transit";
+            case "driving":
+            default:
+                return "drive";
+        }
+    }
+
+    private Intent createYandexMapsIntent(double lat, double lon, Double startLat, Double startLon) {
+        String uri = String.format(Locale.US, "yandexmaps://build_route_on_map/?lat_to=%f&lon_to=%f", lat, lon);
+        if (startLat != null && startLon != null) {
+            uri += String.format(Locale.US, "&lat_from=%f&lon_from=%f", startLat, startLon);
+        }
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("ru.yandex.yandexmaps");
+        return intent;
+    }
+
+    private Intent createMapyIntent(double lat, double lon) {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(String.format(Locale.US, "geo:0,0?q=%f,%f", lat, lon)));
+        intent.setPackage("cz.seznam.mapy");
+        return intent;
+    }
+
+    private Intent create2GisIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        String uri = String.format(Locale.US, "dgis://2gis.ru/routeSearch/rsType/%s", get2GisMode(transportMode));
+        if (startLat != null && startLon != null) {
+            uri += String.format(Locale.US, "/from/%f,%f", startLon, startLat);
+        }
+        uri += String.format(Locale.US, "/to/%f,%f", lon, lat);
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("ru.dublgis.dgismobile");
+        return intent;
+    }
+
+    private String get2GisMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "pedestrian";
+            case "transit":
+                return "ctx";
+            case "driving":
+            case "bicycling":
+            default:
+                return "car";
+        }
+    }
+
     private Intent createCabifyIntent(double lat, double lon, Double startLat, Double startLon) {
         String uri;
         if (startLat != null && startLon != null) {
@@ -267,19 +409,68 @@ public class LaunchNavigator {
         return intent;
     }
 
+    private Intent createTeslaIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, createGoogleMapsWebUrl(lat, lon, startLat, startLon, transportMode));
+        intent.setPackage("com.teslamotors.tesla");
+        return intent;
+    }
+
+    private String createGoogleMapsWebUrl(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        String url = String.format(
+            Locale.US,
+            "https://www.google.com/maps/dir/?api=1&destination=%f,%f&travelmode=%s",
+            lat,
+            lon,
+            getGoogleMapsTravelMode(transportMode)
+        );
+        if (startLat != null && startLon != null) {
+            url += String.format(Locale.US, "&origin=%f,%f", startLat, startLon);
+        }
+        return url;
+    }
+
+    private String getGoogleMapsTravelMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "walking";
+            case "bicycling":
+                return "bicycling";
+            case "transit":
+                return "transit";
+            case "driving":
+            default:
+                return "driving";
+        }
+    }
+
     public boolean isAppAvailable(String app) {
+        Intent intent = createNavigationIntent(app, 0, 0, null, null, null, "driving");
+        return intent != null && canHandleIntent(intent);
+    }
+
+    private boolean canHandleIntent(Intent intent) {
+        PackageManager pm = context.getPackageManager();
+        return intent.resolveActivity(pm) != null || !pm.queryIntentActivities(intent, 0).isEmpty();
+    }
+
+    private String getFirstInstalledPackage(String app) {
         AppInfo appInfo = navigationApps.get(app);
         if (appInfo == null) {
-            return false;
+            return null;
         }
 
         PackageManager pm = context.getPackageManager();
-        try {
-            pm.getPackageInfo(appInfo.packageName, PackageManager.GET_ACTIVITIES);
-            return true;
-        } catch (PackageManager.NameNotFoundException e) {
-            return false;
+        for (String packageName : appInfo.packageNames) {
+            try {
+                pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
+                return packageName;
+            } catch (PackageManager.NameNotFoundException e) {
+                // Try the next package for apps that ship multiple variants.
+            }
         }
+        return null;
     }
 
     public JSArray getAvailableApps() {

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
@@ -22,6 +22,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.json.JSONArray;
@@ -43,6 +45,8 @@ public class LaunchNavigator {
 
     private final Context context;
     private final Bridge bridge;
+    private final Map<String, Object> iconCacheLocks = new ConcurrentHashMap<>();
+    private final ReentrantReadWriteLock iconCacheDirectoryLock = new ReentrantReadWriteLock();
     private Map<String, AppInfo> navigationApps;
 
     private static class AppInfo {
@@ -138,74 +142,9 @@ public class LaunchNavigator {
         String transportMode
     ) {
         try {
-            Intent intent;
+            Intent intent = createNavigationIntent(app, lat, lon, startLat, startLon, destinationName, transportMode);
 
-            switch (app) {
-                case "google_maps":
-                    intent = createGoogleMapsIntent(lat, lon, startLat, startLon, transportMode);
-                    break;
-                case "waze":
-                    intent = createWazeIntent(lat, lon);
-                    break;
-                case "citymapper":
-                    intent = createCitymapperIntent(lat, lon, startLat, startLon);
-                    break;
-                case "uber":
-                    intent = createUberIntent(lat, lon, startLat, startLon);
-                    break;
-                case "yandex":
-                    intent = createYandexIntent(lat, lon, startLat, startLon);
-                    break;
-                case "sygic":
-                    intent = createSygicIntent(lat, lon);
-                    break;
-                case "here":
-                    intent = createHereIntent(lat, lon, startLat, startLon);
-                    break;
-                case "moovit":
-                    intent = createMoovitIntent(lat, lon, startLat, startLon);
-                    break;
-                case "lyft":
-                    intent = createLyftIntent(lat, lon);
-                    break;
-                case "mapsme":
-                    intent = createMapsMeIntent(lat, lon);
-                    break;
-                case "tomtom":
-                    intent = createTomTomIntent(lat, lon);
-                    break;
-                case "guru_maps":
-                    intent = createGuruMapsIntent(lat, lon, startLat, startLon, transportMode);
-                    break;
-                case "organic_maps":
-                    intent = createOrganicMapsIntent(lat, lon, startLat, startLon, destinationName, transportMode);
-                    break;
-                case "yandex_maps":
-                    intent = createYandexMapsIntent(lat, lon, startLat, startLon);
-                    break;
-                case "mapy":
-                    intent = createMapyIntent(lat, lon, transportMode);
-                    break;
-                case "2gis":
-                    intent = create2GisIntent(lat, lon, startLat, startLon, transportMode);
-                    break;
-                case "cabify":
-                    intent = createCabifyIntent(lat, lon, startLat, startLon);
-                    break;
-                case "baidu":
-                    intent = createBaiduIntent(lat, lon, startLat, startLon);
-                    break;
-                case "gaode":
-                    intent = createGaodeIntent(lat, lon, startLat, startLon);
-                    break;
-                case "tesla":
-                    intent = createTeslaIntent(lat, lon, startLat, startLon, transportMode);
-                    break;
-                default:
-                    return false;
-            }
-
-            if (intent != null) {
+            if (intent != null && canResolveIntent(intent)) {
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 context.startActivity(intent);
                 return true;
@@ -215,6 +154,61 @@ public class LaunchNavigator {
         } catch (Exception e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    private Intent createNavigationIntent(
+        String app,
+        double lat,
+        double lon,
+        Double startLat,
+        Double startLon,
+        String destinationName,
+        String transportMode
+    ) {
+        switch (app) {
+            case "google_maps":
+                return createGoogleMapsIntent(lat, lon, startLat, startLon, transportMode);
+            case "waze":
+                return createWazeIntent(lat, lon);
+            case "citymapper":
+                return createCitymapperIntent(lat, lon, startLat, startLon);
+            case "uber":
+                return createUberIntent(lat, lon, startLat, startLon);
+            case "yandex":
+                return createYandexIntent(lat, lon, startLat, startLon);
+            case "sygic":
+                return createSygicIntent(lat, lon);
+            case "here":
+                return createHereIntent(lat, lon, startLat, startLon);
+            case "moovit":
+                return createMoovitIntent(lat, lon, startLat, startLon);
+            case "lyft":
+                return createLyftIntent(lat, lon);
+            case "mapsme":
+                return createMapsMeIntent(lat, lon);
+            case "tomtom":
+                return createTomTomIntent(lat, lon);
+            case "guru_maps":
+                return createGuruMapsIntent(lat, lon, startLat, startLon, transportMode);
+            case "organic_maps":
+                return createOrganicMapsIntent(lat, lon, startLat, startLon, destinationName, transportMode);
+            case "yandex_maps":
+                return createYandexMapsIntent(lat, lon, startLat, startLon);
+            case "mapy":
+                return createMapyIntent(lat, lon, transportMode);
+            case "2gis":
+                return create2GisIntent(lat, lon, startLat, startLon, transportMode);
+            case "cabify":
+                return createCabifyIntent(lat, lon, startLat, startLon);
+            case "baidu":
+                return createBaiduIntent(lat, lon, startLat, startLon);
+            case "gaode":
+                return createGaodeIntent(lat, lon, startLat, startLon);
+            case "tesla":
+                return createTeslaIntent(lat, lon, startLat, startLon, transportMode);
+            default:
+                return null;
         }
     }
 
@@ -527,7 +521,13 @@ public class LaunchNavigator {
     }
 
     public boolean isAppAvailable(String app) {
-        return getFirstInstalledPackage(app) != null;
+        Intent intent = createNavigationIntent(app, 0, 0, null, null, null, "driving");
+        return intent != null && canResolveIntent(intent);
+    }
+
+    private boolean canResolveIntent(Intent intent) {
+        PackageManager pm = context.getPackageManager();
+        return intent.resolveActivity(pm) != null || !pm.queryIntentActivities(intent, 0).isEmpty();
     }
 
     private String getFirstInstalledPackage(String app) {
@@ -586,19 +586,11 @@ public class LaunchNavigator {
             for (int i = 0; i < apps.length(); i++) {
                 String app = apps.optString(i, "");
                 if (!app.isEmpty()) {
-                    cleared += deleteCachedFiles(app);
+                    cleared += clearIconCacheForApp(app);
                 }
             }
         } else {
-            File cacheDirectory = ensureIconCacheDirectory();
-            File[] files = cacheDirectory.listFiles();
-            if (files != null) {
-                for (File file : files) {
-                    if (file.isFile() && file.delete()) {
-                        cleared++;
-                    }
-                }
-            }
+            cleared = clearAllIconCache();
         }
 
         JSObject ret = new JSObject();
@@ -607,6 +599,17 @@ public class LaunchNavigator {
     }
 
     private JSObject resolveProviderIcon(IconProvider provider, long maxAgeMs, boolean forceRefresh) throws Exception {
+        iconCacheDirectoryLock.readLock().lock();
+        try {
+            synchronized (iconCacheLock(provider.app)) {
+                return resolveProviderIconLocked(provider, maxAgeMs, forceRefresh);
+            }
+        } finally {
+            iconCacheDirectoryLock.readLock().unlock();
+        }
+    }
+
+    private JSObject resolveProviderIconLocked(IconProvider provider, long maxAgeMs, boolean forceRefresh) throws Exception {
         CachedIcon cachedIcon = readCachedIcon(provider.app);
         long now = System.currentTimeMillis();
 
@@ -625,12 +628,44 @@ public class LaunchNavigator {
             metadata.put("fetchedAt", now);
             metadata.put("fileName", iconFile.getName());
             writeString(metadataFile(provider.app), metadata.toString());
+            deleteCachedFilesExcept(provider.app, iconFile.getName(), metadataFile(provider.app).getName());
             return createIconObject(new CachedIcon(iconFile, metadata), false, false);
         } catch (Exception e) {
             if (cachedIcon != null) {
                 return createIconObject(cachedIcon, true, true);
             }
             throw e;
+        }
+    }
+
+    private int clearIconCacheForApp(String app) {
+        iconCacheDirectoryLock.readLock().lock();
+        try {
+            synchronized (iconCacheLock(app)) {
+                return deleteCachedFiles(app);
+            }
+        } finally {
+            iconCacheDirectoryLock.readLock().unlock();
+        }
+    }
+
+    private int clearAllIconCache() {
+        iconCacheDirectoryLock.writeLock().lock();
+        try {
+            File cacheDirectory = ensureIconCacheDirectory();
+            File[] files = cacheDirectory.listFiles();
+            int cleared = 0;
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isFile() && file.delete()) {
+                        cleared++;
+                    }
+                }
+            }
+            iconCacheLocks.clear();
+            return cleared;
+        } finally {
+            iconCacheDirectoryLock.writeLock().unlock();
         }
     }
 
@@ -753,33 +788,53 @@ public class LaunchNavigator {
     }
 
     private boolean isSupportedImageResponse(String mimeType, String sourceUrl) {
+        String path = pathForExtension(sourceUrl);
         if (mimeType == null || mimeType.isEmpty()) {
-            return hasKnownImageExtension(sourceUrl);
+            return hasKnownImageExtension(path);
         }
-        return mimeType.startsWith("image/") || (mimeType.equals("application/octet-stream") && hasKnownImageExtension(sourceUrl));
+        return mimeType.startsWith("image/") || (mimeType.equals("application/octet-stream") && hasKnownImageExtension(path));
     }
 
-    private boolean hasKnownImageExtension(String sourceUrl) {
-        String lowerUrl = sourceUrl.toLowerCase(Locale.US);
+    private boolean hasKnownImageExtension(String path) {
+        String lowerPath = path.toLowerCase(Locale.US);
         return (
-            lowerUrl.endsWith(".png") ||
-            lowerUrl.endsWith(".jpg") ||
-            lowerUrl.endsWith(".jpeg") ||
-            lowerUrl.endsWith(".gif") ||
-            lowerUrl.endsWith(".webp") ||
-            lowerUrl.endsWith(".svg") ||
-            lowerUrl.endsWith(".ico")
+            lowerPath.endsWith(".png") ||
+            lowerPath.endsWith(".jpg") ||
+            lowerPath.endsWith(".jpeg") ||
+            lowerPath.endsWith(".gif") ||
+            lowerPath.endsWith(".webp") ||
+            lowerPath.endsWith(".svg") ||
+            lowerPath.endsWith(".ico")
         );
     }
 
     private File writeIcon(String app, DownloadedIcon downloadedIcon) throws IOException {
-        deleteCachedFiles(app);
-        File iconFile = new File(
-            ensureIconCacheDirectory(),
-            cacheKey(app) + guessExtension(downloadedIcon.mimeType, downloadedIcon.sourceUrl)
-        );
-        try (FileOutputStream outputStream = new FileOutputStream(iconFile)) {
+        File cacheDirectory = ensureIconCacheDirectory();
+        File iconFile = new File(cacheDirectory, cacheKey(app) + guessExtension(downloadedIcon.mimeType, downloadedIcon.sourceUrl));
+        File tempFile = new File(cacheDirectory, iconFile.getName() + ".tmp");
+        File backupFile = new File(cacheDirectory, iconFile.getName() + ".bak");
+        if (tempFile.exists()) {
+            tempFile.delete();
+        }
+        if (backupFile.exists()) {
+            backupFile.delete();
+        }
+        try (FileOutputStream outputStream = new FileOutputStream(tempFile)) {
             outputStream.write(downloadedIcon.data);
+        }
+        if (iconFile.exists() && !iconFile.renameTo(backupFile)) {
+            tempFile.delete();
+            throw new IOException("Could not replace cached icon");
+        }
+        if (!tempFile.renameTo(iconFile)) {
+            tempFile.delete();
+            if (backupFile.exists()) {
+                backupFile.renameTo(iconFile);
+            }
+            throw new IOException("Could not store cached icon");
+        }
+        if (backupFile.exists()) {
+            backupFile.delete();
         }
         return iconFile;
     }
@@ -830,6 +885,10 @@ public class LaunchNavigator {
         return new File(ensureIconCacheDirectory(), cacheKey(app) + ".json");
     }
 
+    private Object iconCacheLock(String app) {
+        return iconCacheLocks.computeIfAbsent(cacheKey(app), (key) -> new Object());
+    }
+
     private int deleteCachedFiles(String app) {
         File cacheDirectory = ensureIconCacheDirectory();
         String prefix = cacheKey(app) + ".";
@@ -841,6 +900,30 @@ public class LaunchNavigator {
 
         for (File file : files) {
             if (file.isFile() && file.getName().startsWith(prefix) && file.delete()) {
+                deleted++;
+            }
+        }
+        return deleted;
+    }
+
+    private int deleteCachedFilesExcept(String app, String iconFileName, String metadataFileName) {
+        File cacheDirectory = ensureIconCacheDirectory();
+        String prefix = cacheKey(app) + ".";
+        int deleted = 0;
+        File[] files = cacheDirectory.listFiles();
+        if (files == null) {
+            return 0;
+        }
+
+        for (File file : files) {
+            String fileName = file.getName();
+            if (
+                file.isFile() &&
+                fileName.startsWith(prefix) &&
+                !fileName.equals(iconFileName) &&
+                !fileName.equals(metadataFileName) &&
+                file.delete()
+            ) {
                 deleted++;
             }
         }
@@ -906,17 +989,6 @@ public class LaunchNavigator {
             return selected;
         }
 
-        if (customProviders != null && customProviders.length() > 0) {
-            IconProvider[] selected = new IconProvider[customProviders.length()];
-            for (int i = 0; i < customProviders.length(); i++) {
-                JSONObject providerObject = customProviders.optJSONObject(i);
-                String app = providerObject == null ? "" : providerObject.optString("app", "");
-                IconProvider provider = providers.get(app);
-                selected[i] = provider == null ? new IconProvider(app, null, null, null) : provider;
-            }
-            return selected;
-        }
-
         return providers.values().toArray(new IconProvider[0]);
     }
 
@@ -942,22 +1014,39 @@ public class LaunchNavigator {
             return ".ico";
         }
 
-        String lowerUrl = sourceUrl.toLowerCase(Locale.US);
-        if (lowerUrl.endsWith(".png")) {
+        String lowerPath = pathForExtension(sourceUrl).toLowerCase(Locale.US);
+        if (lowerPath.endsWith(".png")) {
             return ".png";
-        } else if (lowerUrl.endsWith(".jpg") || lowerUrl.endsWith(".jpeg")) {
+        } else if (lowerPath.endsWith(".jpg") || lowerPath.endsWith(".jpeg")) {
             return ".jpg";
-        } else if (lowerUrl.endsWith(".gif")) {
+        } else if (lowerPath.endsWith(".gif")) {
             return ".gif";
-        } else if (lowerUrl.endsWith(".webp")) {
+        } else if (lowerPath.endsWith(".webp")) {
             return ".webp";
-        } else if (lowerUrl.endsWith(".svg")) {
+        } else if (lowerPath.endsWith(".svg")) {
             return ".svg";
-        } else if (lowerUrl.endsWith(".ico")) {
+        } else if (lowerPath.endsWith(".ico")) {
             return ".ico";
         }
 
         return ".img";
+    }
+
+    private String pathForExtension(String sourceUrl) {
+        try {
+            return new URL(sourceUrl).getPath();
+        } catch (Exception e) {
+            int queryIndex = sourceUrl.indexOf('?');
+            int fragmentIndex = sourceUrl.indexOf('#');
+            int endIndex = sourceUrl.length();
+            if (queryIndex >= 0) {
+                endIndex = Math.min(endIndex, queryIndex);
+            }
+            if (fragmentIndex >= 0) {
+                endIndex = Math.min(endIndex, fragmentIndex);
+            }
+            return sourceUrl.substring(0, endIndex);
+        }
     }
 
     private String cacheKey(String app) {

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
@@ -4,48 +4,127 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import com.getcapacitor.Bridge;
+import com.getcapacitor.FileUtils;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
-import java.util.HashMap;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 public class LaunchNavigator {
 
-    private Context context;
+    private static final long DEFAULT_ICON_CACHE_MAX_AGE_MS = 24L * 60L * 60L * 1000L;
+    private static final int CONNECT_TIMEOUT_MS = 8000;
+    private static final int READ_TIMEOUT_MS = 8000;
+    private static final int MAX_ICON_BYTES = 2 * 1024 * 1024;
+    private static final int MAX_HTML_BYTES = 512 * 1024;
+    private static final String ICON_CACHE_DIR = "launch_navigator_icons";
+    private static final Pattern ICON_LINK_PATTERN = Pattern.compile(
+        "<link\\s+[^>]*rel=[\"'][^\"']*(?:apple-touch-icon|icon)[^\"']*[\"'][^>]*>",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern HREF_PATTERN = Pattern.compile("\\shref=[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+
+    private final Context context;
+    private final Bridge bridge;
     private Map<String, AppInfo> navigationApps;
 
     private static class AppInfo {
 
         String name;
-        String packageName;
+        String[] packageNames;
+        String url;
 
-        AppInfo(String name, String packageName) {
+        AppInfo(String name, String url, String... packageNames) {
             this.name = name;
-            this.packageName = packageName;
+            this.url = url;
+            this.packageNames = packageNames;
         }
     }
 
-    public LaunchNavigator(Context context) {
+    private static class IconProvider {
+
+        String app;
+        String name;
+        String url;
+        String iconUrl;
+
+        IconProvider(String app, String name, String url, String iconUrl) {
+            this.app = app;
+            this.name = name;
+            this.url = url;
+            this.iconUrl = iconUrl;
+        }
+    }
+
+    private static class CachedIcon {
+
+        File file;
+        JSONObject metadata;
+
+        CachedIcon(File file, JSONObject metadata) {
+            this.file = file;
+            this.metadata = metadata;
+        }
+    }
+
+    private static class DownloadedIcon {
+
+        byte[] data;
+        String sourceUrl;
+        String mimeType;
+
+        DownloadedIcon(byte[] data, String sourceUrl, String mimeType) {
+            this.data = data;
+            this.sourceUrl = sourceUrl;
+            this.mimeType = mimeType;
+        }
+    }
+
+    public LaunchNavigator(Context context, Bridge bridge) {
         this.context = context;
+        this.bridge = bridge;
         initializeApps();
     }
 
     private void initializeApps() {
-        navigationApps = new HashMap<>();
-        navigationApps.put("google_maps", new AppInfo("Google Maps", "com.google.android.apps.maps"));
-        navigationApps.put("waze", new AppInfo("Waze", "com.waze"));
-        navigationApps.put("citymapper", new AppInfo("Citymapper", "com.citymapper.app.release"));
-        navigationApps.put("uber", new AppInfo("Uber", "com.ubercab"));
-        navigationApps.put("yandex", new AppInfo("Yandex Navigator", "ru.yandex.yandexnavi"));
-        navigationApps.put("sygic", new AppInfo("Sygic", "com.sygic.aura"));
-        navigationApps.put("here", new AppInfo("HERE Maps", "com.here.app.maps"));
-        navigationApps.put("moovit", new AppInfo("Moovit", "com.tranzmate"));
-        navigationApps.put("lyft", new AppInfo("Lyft", "me.lyft.android"));
-        navigationApps.put("mapsme", new AppInfo("MAPS.ME", "com.mapswithme.maps.pro"));
-        navigationApps.put("cabify", new AppInfo("Cabify", "com.cabify.rider"));
-        navigationApps.put("baidu", new AppInfo("Baidu Maps", "com.baidu.BaiduMap"));
-        navigationApps.put("gaode", new AppInfo("Gaode Maps", "com.autonavi.minimap"));
+        navigationApps = new LinkedHashMap<>();
+        navigationApps.put("google_maps", new AppInfo("Google Maps", "https://www.google.com/maps", "com.google.android.apps.maps"));
+        navigationApps.put("waze", new AppInfo("Waze", "https://www.waze.com", "com.waze"));
+        navigationApps.put("citymapper", new AppInfo("Citymapper", "https://citymapper.com", "com.citymapper.app.release"));
+        navigationApps.put("uber", new AppInfo("Uber", "https://www.uber.com", "com.ubercab"));
+        navigationApps.put("yandex", new AppInfo("Yandex Navigator", "https://yandex.com/maps", "ru.yandex.yandexnavi"));
+        navigationApps.put("sygic", new AppInfo("Sygic", "https://www.sygic.com/gps-navigation", "com.sygic.aura"));
+        navigationApps.put("here", new AppInfo("HERE Maps", "https://wego.here.com", "com.here.app.maps"));
+        navigationApps.put("moovit", new AppInfo("Moovit", "https://moovitapp.com", "com.tranzmate"));
+        navigationApps.put("lyft", new AppInfo("Lyft", "https://www.lyft.com", "me.lyft.android"));
+        navigationApps.put("mapsme", new AppInfo("MAPS.ME", "https://maps.me", "com.mapswithme.maps.pro"));
+        navigationApps.put("tomtom", new AppInfo("TomTom GO", "https://www.tomtom.com", "com.tomtom.gplay.navapp"));
+        navigationApps.put("guru_maps", new AppInfo("Guru Maps", "https://gurumaps.app", "com.bodunov.galileo", "com.bodunov.GalileoPro"));
+        navigationApps.put("organic_maps", new AppInfo("Organic Maps", "https://organicmaps.app", "app.organicmaps"));
+        navigationApps.put("yandex_maps", new AppInfo("Yandex Maps", "https://yandex.com/maps", "ru.yandex.yandexmaps"));
+        navigationApps.put("mapy", new AppInfo("Mapy.com", "https://mapy.com", "cz.seznam.mapy"));
+        navigationApps.put("2gis", new AppInfo("2GIS", "https://2gis.com", "ru.dublgis.dgismobile"));
+        navigationApps.put("cabify", new AppInfo("Cabify", "https://cabify.com", "com.cabify.rider"));
+        navigationApps.put("baidu", new AppInfo("Baidu Maps", "https://map.baidu.com", "com.baidu.BaiduMap"));
+        navigationApps.put("gaode", new AppInfo("Gaode Maps", "https://www.amap.com", "com.autonavi.minimap"));
+        navigationApps.put("tesla", new AppInfo("Tesla", "https://www.tesla.com", "com.teslamotors.tesla"));
     }
 
     public boolean navigate(
@@ -92,6 +171,24 @@ public class LaunchNavigator {
                 case "mapsme":
                     intent = createMapsMeIntent(lat, lon);
                     break;
+                case "tomtom":
+                    intent = createTomTomIntent(lat, lon);
+                    break;
+                case "guru_maps":
+                    intent = createGuruMapsIntent(lat, lon, startLat, startLon, transportMode);
+                    break;
+                case "organic_maps":
+                    intent = createOrganicMapsIntent(lat, lon, startLat, startLon, destinationName, transportMode);
+                    break;
+                case "yandex_maps":
+                    intent = createYandexMapsIntent(lat, lon, startLat, startLon);
+                    break;
+                case "mapy":
+                    intent = createMapyIntent(lat, lon, transportMode);
+                    break;
+                case "2gis":
+                    intent = create2GisIntent(lat, lon, startLat, startLon, transportMode);
+                    break;
                 case "cabify":
                     intent = createCabifyIntent(lat, lon, startLat, startLon);
                     break;
@@ -100,6 +197,9 @@ public class LaunchNavigator {
                     break;
                 case "gaode":
                     intent = createGaodeIntent(lat, lon, startLat, startLon);
+                    break;
+                case "tesla":
+                    intent = createTeslaIntent(lat, lon, startLat, startLon, transportMode);
                     break;
                 default:
                     return false;
@@ -230,6 +330,129 @@ public class LaunchNavigator {
         return new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
     }
 
+    private Intent createTomTomIntent(double lat, double lon) {
+        String uri = String.format(Locale.US, "tomtomgo://x-callback-url/navigate?destination=%f,%f", lat, lon);
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("com.tomtom.gplay.navapp");
+        return intent;
+    }
+
+    private Intent createGuruMapsIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        String uri = String.format(
+            Locale.US,
+            "guru://nav?finish=%f,%f&mode=%s&start_navigation=true",
+            lat,
+            lon,
+            getGuruMapsMode(transportMode)
+        );
+        if (startLat != null && startLon != null) {
+            uri += String.format(Locale.US, "&start=%f,%f", startLat, startLon);
+        }
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        String packageName = getFirstInstalledPackage("guru_maps");
+        if (packageName != null) {
+            intent.setPackage(packageName);
+        }
+        return intent;
+    }
+
+    private String getGuruMapsMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "pedestrian";
+            case "bicycling":
+                return "bicycle";
+            case "driving":
+            case "transit":
+            default:
+                return "auto";
+        }
+    }
+
+    private Intent createOrganicMapsIntent(
+        double lat,
+        double lon,
+        Double startLat,
+        Double startLon,
+        String destinationName,
+        String transportMode
+    ) {
+        String origin = "currentLocation";
+        if (startLat != null && startLon != null) {
+            origin = String.format(Locale.US, "%f,%f", startLat, startLon);
+        }
+
+        String uri = String.format(
+            Locale.US,
+            "om://v2/nav?origin=%s&destination=%f,%f&mode=%s",
+            Uri.encode(origin),
+            lat,
+            lon,
+            getOrganicMapsMode(transportMode)
+        );
+        if (destinationName != null && !destinationName.isEmpty()) {
+            uri += "&destination_name=" + Uri.encode(destinationName);
+        }
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("app.organicmaps");
+        return intent;
+    }
+
+    private String getOrganicMapsMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "pedestrian";
+            case "bicycling":
+                return "bicycle";
+            case "transit":
+                return "transit";
+            case "driving":
+            default:
+                return "drive";
+        }
+    }
+
+    private Intent createYandexMapsIntent(double lat, double lon, Double startLat, Double startLon) {
+        String uri = String.format(Locale.US, "yandexmaps://build_route_on_map/?lat_to=%f&lon_to=%f", lat, lon);
+        if (startLat != null && startLon != null) {
+            uri += String.format(Locale.US, "&lat_from=%f&lon_from=%f", startLat, startLon);
+        }
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("ru.yandex.yandexmaps");
+        return intent;
+    }
+
+    private Intent createMapyIntent(double lat, double lon, String transportMode) {
+        String uri = String.format(Locale.US, "google.navigation:q=%f,%f&mode=%s", lat, lon, getGoogleMapsMode(transportMode));
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("cz.seznam.mapy");
+        return intent;
+    }
+
+    private Intent create2GisIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        String uri = String.format(Locale.US, "dgis://2gis.ru/routeSearch/rsType/%s", get2GisMode(transportMode));
+        if (startLat != null && startLon != null) {
+            uri += String.format(Locale.US, "/from/%f,%f", startLon, startLat);
+        }
+        uri += String.format(Locale.US, "/to/%f,%f", lon, lat);
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("ru.dublgis.dgismobile");
+        return intent;
+    }
+
+    private String get2GisMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "pedestrian";
+            case "transit":
+                return "ctx";
+            case "driving":
+            case "bicycling":
+            default:
+                return "car";
+        }
+    }
+
     private Intent createCabifyIntent(double lat, double lon, Double startLat, Double startLon) {
         String uri;
         if (startLat != null && startLon != null) {
@@ -267,18 +490,493 @@ public class LaunchNavigator {
         return intent;
     }
 
+    private Intent createTeslaIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, createGoogleMapsWebUrl(lat, lon, startLat, startLon, transportMode));
+        intent.setPackage("com.teslamotors.tesla");
+        return intent;
+    }
+
+    private String createGoogleMapsWebUrl(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+        String url = String.format(
+            Locale.US,
+            "https://www.google.com/maps/dir/?api=1&destination=%f,%f&travelmode=%s",
+            lat,
+            lon,
+            getGoogleMapsTravelMode(transportMode)
+        );
+        if (startLat != null && startLon != null) {
+            url += String.format(Locale.US, "&origin=%f,%f", startLat, startLon);
+        }
+        return url;
+    }
+
+    private String getGoogleMapsTravelMode(String transportMode) {
+        switch (transportMode) {
+            case "walking":
+                return "walking";
+            case "bicycling":
+                return "bicycling";
+            case "transit":
+                return "transit";
+            case "driving":
+            default:
+                return "driving";
+        }
+    }
+
     public boolean isAppAvailable(String app) {
+        return getFirstInstalledPackage(app) != null;
+    }
+
+    private String getFirstInstalledPackage(String app) {
         AppInfo appInfo = navigationApps.get(app);
         if (appInfo == null) {
-            return false;
+            return null;
         }
 
         PackageManager pm = context.getPackageManager();
+        for (String packageName : appInfo.packageNames) {
+            try {
+                pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
+                return packageName;
+            } catch (PackageManager.NameNotFoundException e) {
+                // Try the next package for apps that ship free and pro variants.
+            }
+        }
+        return null;
+    }
+
+    public JSObject getAppIcons(JSObject options) {
+        return getAppIcons(options, false);
+    }
+
+    public JSObject refreshAppIcons(JSObject options) {
+        return getAppIcons(options, true);
+    }
+
+    private JSObject getAppIcons(JSObject options, boolean forceRefreshOverride) {
+        JSObject safeOptions = options == null ? new JSObject() : options;
+        long maxAgeMs = getMaxAgeMs(safeOptions);
+        boolean forceRefresh = forceRefreshOverride || safeOptions.optBoolean("forceRefresh", false);
+        JSArray icons = new JSArray();
+        JSArray failures = new JSArray();
+
+        for (IconProvider provider : resolveIconProviders(safeOptions)) {
+            try {
+                icons.put(resolveProviderIcon(provider, maxAgeMs, forceRefresh));
+            } catch (Exception e) {
+                failures.put(createIconFailure(provider, e));
+            }
+        }
+
+        JSObject ret = new JSObject();
+        ret.put("icons", icons);
+        ret.put("failures", failures);
+        return ret;
+    }
+
+    public JSObject clearIconCache(JSObject options) {
+        JSObject safeOptions = options == null ? new JSObject() : options;
+        JSONArray apps = safeOptions.optJSONArray("apps");
+        int cleared = 0;
+
+        if (apps != null && apps.length() > 0) {
+            for (int i = 0; i < apps.length(); i++) {
+                String app = apps.optString(i, "");
+                if (!app.isEmpty()) {
+                    cleared += deleteCachedFiles(app);
+                }
+            }
+        } else {
+            File cacheDirectory = ensureIconCacheDirectory();
+            File[] files = cacheDirectory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isFile() && file.delete()) {
+                        cleared++;
+                    }
+                }
+            }
+        }
+
+        JSObject ret = new JSObject();
+        ret.put("cleared", cleared);
+        return ret;
+    }
+
+    private JSObject resolveProviderIcon(IconProvider provider, long maxAgeMs, boolean forceRefresh) throws Exception {
+        CachedIcon cachedIcon = readCachedIcon(provider.app);
+        long now = System.currentTimeMillis();
+
+        if (cachedIcon != null && !forceRefresh && now - cachedIcon.metadata.optLong("fetchedAt", 0) < maxAgeMs) {
+            return createIconObject(cachedIcon, true, false);
+        }
+
         try {
-            pm.getPackageInfo(appInfo.packageName, PackageManager.GET_ACTIVITIES);
-            return true;
-        } catch (PackageManager.NameNotFoundException e) {
-            return false;
+            DownloadedIcon downloadedIcon = downloadIcon(provider);
+            File iconFile = writeIcon(provider.app, downloadedIcon);
+            JSONObject metadata = new JSONObject();
+            metadata.put("app", provider.app);
+            metadata.put("name", provider.name);
+            metadata.put("sourceUrl", downloadedIcon.sourceUrl);
+            metadata.put("mimeType", downloadedIcon.mimeType);
+            metadata.put("fetchedAt", now);
+            metadata.put("fileName", iconFile.getName());
+            writeString(metadataFile(provider.app), metadata.toString());
+            return createIconObject(new CachedIcon(iconFile, metadata), false, false);
+        } catch (Exception e) {
+            if (cachedIcon != null) {
+                return createIconObject(cachedIcon, true, true);
+            }
+            throw e;
+        }
+    }
+
+    private JSObject createIconObject(CachedIcon cachedIcon, boolean fromCache, boolean stale) {
+        JSObject icon = new JSObject();
+        icon.put("app", cachedIcon.metadata.optString("app"));
+        String name = cachedIcon.metadata.optString("name", null);
+        if (name != null && !name.isEmpty()) {
+            icon.put("name", name);
+        }
+        icon.put("localUrl", portablePath(cachedIcon.file));
+        icon.put("sourceUrl", cachedIcon.metadata.optString("sourceUrl"));
+        String mimeType = cachedIcon.metadata.optString("mimeType", null);
+        if (mimeType != null && !mimeType.isEmpty()) {
+            icon.put("mimeType", mimeType);
+        }
+        icon.put("fetchedAt", cachedIcon.metadata.optLong("fetchedAt", 0));
+        icon.put("fromCache", fromCache);
+        icon.put("stale", stale);
+        return icon;
+    }
+
+    private JSObject createIconFailure(IconProvider provider, Exception error) {
+        JSObject failure = new JSObject();
+        failure.put("app", provider.app);
+        if (provider.name != null && !provider.name.isEmpty()) {
+            failure.put("name", provider.name);
+        }
+        String sourceUrl = provider.iconUrl != null ? provider.iconUrl : provider.url;
+        if (sourceUrl != null && !sourceUrl.isEmpty()) {
+            failure.put("sourceUrl", sourceUrl);
+        }
+        failure.put("message", error.getMessage() == null ? error.toString() : error.getMessage());
+        return failure;
+    }
+
+    private DownloadedIcon downloadIcon(IconProvider provider) throws IOException {
+        String sourceUrl;
+        if (provider.iconUrl != null && !provider.iconUrl.isEmpty()) {
+            sourceUrl = resolveUrl(provider.iconUrl, provider.url);
+        } else {
+            if (provider.url == null || provider.url.isEmpty()) {
+                throw new IOException("Provider url or iconUrl is required");
+            }
+            sourceUrl = discoverIconUrl(provider.url);
+        }
+
+        HttpURLConnection connection = openConnection(sourceUrl);
+        try {
+            int status = connection.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new IOException("Icon request failed with status " + status);
+            }
+
+            String mimeType = normalizeMimeType(connection.getContentType());
+            byte[] data = readLimitedBytes(connection.getInputStream(), MAX_ICON_BYTES);
+            if (!isSupportedImageResponse(mimeType, sourceUrl)) {
+                throw new IOException("Icon response is not an image");
+            }
+            return new DownloadedIcon(data, connection.getURL().toString(), mimeType);
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private String discoverIconUrl(String providerUrl) throws IOException {
+        HttpURLConnection connection = openConnection(providerUrl);
+        try {
+            int status = connection.getResponseCode();
+            if (status < 200 || status >= 300) {
+                throw new IOException("Provider page request failed with status " + status);
+            }
+
+            String html = new String(readLimitedBytes(connection.getInputStream(), MAX_HTML_BYTES), StandardCharsets.UTF_8);
+            Matcher linkMatcher = ICON_LINK_PATTERN.matcher(html);
+            if (linkMatcher.find()) {
+                Matcher hrefMatcher = HREF_PATTERN.matcher(linkMatcher.group());
+                if (hrefMatcher.find()) {
+                    return resolveUrl(hrefMatcher.group(1), connection.getURL().toString());
+                }
+            }
+
+            return resolveUrl("/favicon.ico", connection.getURL().toString());
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private HttpURLConnection openConnection(String url) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        connection.setReadTimeout(READ_TIMEOUT_MS);
+        connection.setInstanceFollowRedirects(true);
+        connection.setRequestProperty("User-Agent", "CapgoLaunchNavigator/8");
+        return connection;
+    }
+
+    private String resolveUrl(String url, String baseUrl) throws IOException {
+        if (baseUrl != null && !baseUrl.isEmpty()) {
+            return new URL(new URL(baseUrl), url).toString();
+        }
+        return new URL(url).toString();
+    }
+
+    private byte[] readLimitedBytes(InputStream inputStream, int maxBytes) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int total = 0;
+        int read;
+
+        while ((read = inputStream.read(buffer)) != -1) {
+            total += read;
+            if (total > maxBytes) {
+                throw new IOException("Response is too large");
+            }
+            outputStream.write(buffer, 0, read);
+        }
+
+        return outputStream.toByteArray();
+    }
+
+    private boolean isSupportedImageResponse(String mimeType, String sourceUrl) {
+        if (mimeType == null || mimeType.isEmpty()) {
+            return hasKnownImageExtension(sourceUrl);
+        }
+        return mimeType.startsWith("image/") || (mimeType.equals("application/octet-stream") && hasKnownImageExtension(sourceUrl));
+    }
+
+    private boolean hasKnownImageExtension(String sourceUrl) {
+        String lowerUrl = sourceUrl.toLowerCase(Locale.US);
+        return (
+            lowerUrl.endsWith(".png") ||
+            lowerUrl.endsWith(".jpg") ||
+            lowerUrl.endsWith(".jpeg") ||
+            lowerUrl.endsWith(".gif") ||
+            lowerUrl.endsWith(".webp") ||
+            lowerUrl.endsWith(".svg") ||
+            lowerUrl.endsWith(".ico")
+        );
+    }
+
+    private File writeIcon(String app, DownloadedIcon downloadedIcon) throws IOException {
+        deleteCachedFiles(app);
+        File iconFile = new File(
+            ensureIconCacheDirectory(),
+            cacheKey(app) + guessExtension(downloadedIcon.mimeType, downloadedIcon.sourceUrl)
+        );
+        try (FileOutputStream outputStream = new FileOutputStream(iconFile)) {
+            outputStream.write(downloadedIcon.data);
+        }
+        return iconFile;
+    }
+
+    private CachedIcon readCachedIcon(String app) {
+        File metadata = metadataFile(app);
+        if (!metadata.exists()) {
+            return null;
+        }
+
+        try {
+            JSONObject metadataObject = new JSONObject(readString(metadata));
+            String fileName = metadataObject.optString("fileName", "");
+            if (fileName.isEmpty()) {
+                return null;
+            }
+            File iconFile = new File(ensureIconCacheDirectory(), fileName);
+            if (!iconFile.exists()) {
+                return null;
+            }
+            return new CachedIcon(iconFile, metadataObject);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String readString(File file) throws IOException {
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            return new String(readLimitedBytes(inputStream, MAX_HTML_BYTES), StandardCharsets.UTF_8);
+        }
+    }
+
+    private void writeString(File file, String value) throws IOException {
+        try (FileOutputStream outputStream = new FileOutputStream(file)) {
+            outputStream.write(value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private File ensureIconCacheDirectory() {
+        File directory = new File(context.getCacheDir(), ICON_CACHE_DIR);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
+        return directory;
+    }
+
+    private File metadataFile(String app) {
+        return new File(ensureIconCacheDirectory(), cacheKey(app) + ".json");
+    }
+
+    private int deleteCachedFiles(String app) {
+        File cacheDirectory = ensureIconCacheDirectory();
+        String prefix = cacheKey(app) + ".";
+        int deleted = 0;
+        File[] files = cacheDirectory.listFiles();
+        if (files == null) {
+            return 0;
+        }
+
+        for (File file : files) {
+            if (file.isFile() && file.getName().startsWith(prefix) && file.delete()) {
+                deleted++;
+            }
+        }
+        return deleted;
+    }
+
+    private String portablePath(File file) {
+        String host = bridge == null ? null : bridge.getLocalUrl();
+        if (host == null || host.isEmpty()) {
+            return Uri.fromFile(file).toString();
+        }
+        return FileUtils.getPortablePath(context, host, Uri.fromFile(file));
+    }
+
+    private long getMaxAgeMs(JSObject options) {
+        if (!options.has("maxAgeMs")) {
+            return DEFAULT_ICON_CACHE_MAX_AGE_MS;
+        }
+
+        double maxAgeMs = options.optDouble("maxAgeMs", DEFAULT_ICON_CACHE_MAX_AGE_MS);
+        if (Double.isNaN(maxAgeMs) || maxAgeMs < 0) {
+            return DEFAULT_ICON_CACHE_MAX_AGE_MS;
+        }
+        return (long) maxAgeMs;
+    }
+
+    private IconProvider[] resolveIconProviders(JSObject options) {
+        Map<String, IconProvider> providers = new LinkedHashMap<>();
+
+        for (Map.Entry<String, AppInfo> entry : navigationApps.entrySet()) {
+            providers.put(entry.getKey(), new IconProvider(entry.getKey(), entry.getValue().name, entry.getValue().url, null));
+        }
+
+        JSONArray customProviders = options.optJSONArray("providers");
+        if (customProviders != null) {
+            for (int i = 0; i < customProviders.length(); i++) {
+                JSONObject providerObject = customProviders.optJSONObject(i);
+                if (providerObject == null) {
+                    continue;
+                }
+
+                String app = providerObject.optString("app", "");
+                if (app.isEmpty()) {
+                    continue;
+                }
+
+                IconProvider existing = providers.get(app);
+                String name = providerObject.optString("name", existing == null ? null : existing.name);
+                String url = providerObject.optString("url", existing == null ? null : existing.url);
+                String iconUrl = providerObject.optString("iconUrl", existing == null ? null : existing.iconUrl);
+                providers.put(app, new IconProvider(app, name, url, iconUrl));
+            }
+        }
+
+        JSONArray apps = options.optJSONArray("apps");
+        if (apps != null && apps.length() > 0) {
+            IconProvider[] selected = new IconProvider[apps.length()];
+            for (int i = 0; i < apps.length(); i++) {
+                String app = apps.optString(i, "");
+                IconProvider provider = providers.get(app);
+                selected[i] = provider == null ? new IconProvider(app, null, null, null) : provider;
+            }
+            return selected;
+        }
+
+        if (customProviders != null && customProviders.length() > 0) {
+            IconProvider[] selected = new IconProvider[customProviders.length()];
+            for (int i = 0; i < customProviders.length(); i++) {
+                JSONObject providerObject = customProviders.optJSONObject(i);
+                String app = providerObject == null ? "" : providerObject.optString("app", "");
+                IconProvider provider = providers.get(app);
+                selected[i] = provider == null ? new IconProvider(app, null, null, null) : provider;
+            }
+            return selected;
+        }
+
+        return providers.values().toArray(new IconProvider[0]);
+    }
+
+    private String normalizeMimeType(String mimeType) {
+        if (mimeType == null) {
+            return null;
+        }
+        return mimeType.split(";")[0].trim().toLowerCase(Locale.US);
+    }
+
+    private String guessExtension(String mimeType, String sourceUrl) {
+        if ("image/jpeg".equals(mimeType)) {
+            return ".jpg";
+        } else if ("image/png".equals(mimeType)) {
+            return ".png";
+        } else if ("image/gif".equals(mimeType)) {
+            return ".gif";
+        } else if ("image/webp".equals(mimeType)) {
+            return ".webp";
+        } else if ("image/svg+xml".equals(mimeType)) {
+            return ".svg";
+        } else if ("image/x-icon".equals(mimeType) || "image/vnd.microsoft.icon".equals(mimeType)) {
+            return ".ico";
+        }
+
+        String lowerUrl = sourceUrl.toLowerCase(Locale.US);
+        if (lowerUrl.endsWith(".png")) {
+            return ".png";
+        } else if (lowerUrl.endsWith(".jpg") || lowerUrl.endsWith(".jpeg")) {
+            return ".jpg";
+        } else if (lowerUrl.endsWith(".gif")) {
+            return ".gif";
+        } else if (lowerUrl.endsWith(".webp")) {
+            return ".webp";
+        } else if (lowerUrl.endsWith(".svg")) {
+            return ".svg";
+        } else if (lowerUrl.endsWith(".ico")) {
+            return ".ico";
+        }
+
+        return ".img";
+    }
+
+    private String cacheKey(String app) {
+        String safeApp = app.replaceAll("[^A-Za-z0-9._-]", "_");
+        String hash = hashed(app);
+        return safeApp + "_" + hash.substring(0, Math.min(8, hash.length()));
+    }
+
+    private String hashed(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encoded = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : encoded) {
+                sb.append(String.format(Locale.US, "%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return String.valueOf(input.hashCode());
         }
     }
 

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigatorPlugin.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigatorPlugin.java
@@ -16,7 +16,7 @@ public class LaunchNavigatorPlugin extends Plugin {
 
     @Override
     public void load() {
-        implementation = new LaunchNavigator(getContext());
+        implementation = new LaunchNavigator(getContext(), getBridge());
     }
 
     @PluginMethod
@@ -102,6 +102,66 @@ public class LaunchNavigatorPlugin extends Plugin {
         JSObject ret = new JSObject();
         ret.put("app", "google_maps");
         call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void getAppIcons(PluginCall call) {
+        JSObject options = new JSObject();
+        try {
+            options = new JSObject(call.getData().toString());
+        } catch (Exception e) {
+            call.reject("Invalid icon options: " + e.getMessage());
+            return;
+        }
+
+        JSObject finalOptions = options;
+        execute(() -> {
+            try {
+                call.resolve(implementation.getAppIcons(finalOptions));
+            } catch (Exception e) {
+                call.reject("Could not get app icons: " + e.getMessage(), e);
+            }
+        });
+    }
+
+    @PluginMethod
+    public void refreshAppIcons(PluginCall call) {
+        JSObject options = new JSObject();
+        try {
+            options = new JSObject(call.getData().toString());
+        } catch (Exception e) {
+            call.reject("Invalid icon options: " + e.getMessage());
+            return;
+        }
+
+        JSObject finalOptions = options;
+        execute(() -> {
+            try {
+                call.resolve(implementation.refreshAppIcons(finalOptions));
+            } catch (Exception e) {
+                call.reject("Could not refresh app icons: " + e.getMessage(), e);
+            }
+        });
+    }
+
+    @PluginMethod
+    public void clearIconCache(PluginCall call) {
+        JSObject options = new JSObject();
+        try {
+            options = new JSObject(call.getData().toString());
+        } catch (Exception e) {
+            call.reject("Invalid icon cache options: " + e.getMessage());
+            return;
+        }
+
+        JSObject finalOptions = options;
+        execute(() -> {
+            try {
+                call.resolve(implementation.clearIconCache(finalOptions));
+            } catch (Exception e) {
+                call.reject("Could not clear icon cache: " + e.getMessage(), e);
+            }
+        });
     }
 
     @PluginMethod

--- a/example-app/bun.lock
+++ b/example-app/bun.lock
@@ -9,7 +9,7 @@
         "@capacitor/camera": "^8.0.0",
         "@capacitor/core": "^8.0.0",
         "@capacitor/ios": "^8.0.0",
-        "@capacitor/splash-screen": "^7.0.3",
+        "@capacitor/splash-screen": "^8.0.0",
         "@capgo/capacitor-launch-navigator": "file:..",
       },
       "devDependencies": {
@@ -35,7 +35,7 @@
 
     "@capacitor/ios": ["@capacitor/ios@8.3.3", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-BHlTOxarrvkaqDdlTxKwip+dQmfQSnfctizpheR7SWp/VIlR0HcPpYzWMTiVbHQLq3nLRUdeZO1wSPVGvxzAPA=="],
 
-    "@capacitor/splash-screen": ["@capacitor/splash-screen@7.0.5", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-bPG2SamFL7VT5I3XsgsGgJhkiyxq3OXCOVKEDupSieVdtEiG7j2vLbSD0xL+91zteF/qLuxsjbugGy5LD8mS2A=="],
+    "@capacitor/splash-screen": ["@capacitor/splash-screen@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg=="],
 
     "@capgo/capacitor-launch-navigator": ["@capgo/capacitor-launch-navigator@file:..", { "devDependencies": { "@capacitor/android": "^8.0.0", "@capacitor/core": "^8.0.0", "@capacitor/docgen": "^0.3.1", "@capacitor/ios": "^8.0.0", "@ionic/eslint-config": "^0.4.0", "@ionic/prettier-config": "^4.0.0", "@ionic/swiftlint-config": "^2.0.0", "@types/node": "^24.10.1", "eslint": "^8.57.1", "eslint-plugin-import": "^2.31.0", "prettier": "^3.6.2", "prettier-plugin-java": "^2.7.7", "prettier-pretty-check": "^0.2.0", "rimraf": "^6.1.0", "rollup": "^4.53.2", "swiftlint": "^2.0.0", "typescript": "^5.9.3" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }],
 

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -17,7 +17,7 @@
     "@capacitor/camera": "^8.0.0",
     "@capacitor/core": "^8.0.0",
     "@capacitor/ios": "^8.0.0",
-    "@capacitor/splash-screen": "^7.0.3",
+    "@capacitor/splash-screen": "^8.0.0",
     "@capgo/capacitor-launch-navigator": "file:.."
   },
   "devDependencies": {

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
@@ -551,7 +551,9 @@ struct NavigationAppInfo {
     }
 
     private func encoded(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+        var allowed = CharacterSet.urlQueryAllowed
+        allowed.remove(charactersIn: "&=+/?#")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 
     private func openURL(_ urlString: String, completion: @escaping (Bool, String?) -> Void) {

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
@@ -2,29 +2,44 @@ import Foundation
 import UIKit
 import MapKit
 
+struct NavigationAppInfo {
+    let name: String
+    let urlScheme: String
+    let url: String
+}
+
+// swiftlint:disable type_body_length
 @objc public class LaunchNavigator: NSObject {
 
-    private let navigationApps: [String: (name: String, urlScheme: String)] = [
-        "apple_maps": ("Apple Maps", "maps://"),
-        "google_maps": ("Google Maps", "comgooglemaps://"),
-        "waze": ("Waze", "waze://"),
-        "citymapper": ("Citymapper", "citymapper://"),
-        "garmin_navigon": ("Garmin Navigon", "navigon://"),
-        "transit_app": ("Transit App", "transit://"),
-        "yandex": ("Yandex Navigator", "yandexnavi://"),
-        "uber": ("Uber", "uber://"),
-        "tomtom": ("TomTom", "tomtomgo://"),
-        "sygic": ("Sygic", "com.sygic.aura://"),
-        "here": ("HERE Maps", "here-route://"),
-        "moovit": ("Moovit", "moovit://"),
-        "lyft": ("Lyft", "lyft://"),
-        "mapsme": ("MAPS.ME", "mapsme://"),
-        "cabify": ("Cabify", "cabify://"),
-        "baidu": ("Baidu Maps", "baidumap://"),
-        "gaode": ("Gaode Maps", "iosamap://"),
-        "99taxi": ("99 Taxi", "99app://")
+    public var webPathResolver: ((URL) -> String?)?
+
+    let navigationApps: [String: NavigationAppInfo] = [
+        "apple_maps": NavigationAppInfo(name: "Apple Maps", urlScheme: "maps://", url: "https://www.apple.com/maps/"),
+        "google_maps": NavigationAppInfo(name: "Google Maps", urlScheme: "comgooglemaps://", url: "https://www.google.com/maps"),
+        "waze": NavigationAppInfo(name: "Waze", urlScheme: "waze://", url: "https://www.waze.com"),
+        "citymapper": NavigationAppInfo(name: "Citymapper", urlScheme: "citymapper://", url: "https://citymapper.com"),
+        "garmin_navigon": NavigationAppInfo(name: "Garmin Navigon", urlScheme: "navigon://", url: "https://www.garmin.com"),
+        "transit_app": NavigationAppInfo(name: "Transit App", urlScheme: "transit://", url: "https://transitapp.com"),
+        "yandex": NavigationAppInfo(name: "Yandex Navigator", urlScheme: "yandexnavi://", url: "https://yandex.com/maps"),
+        "uber": NavigationAppInfo(name: "Uber", urlScheme: "uber://", url: "https://www.uber.com"),
+        "tomtom": NavigationAppInfo(name: "TomTom", urlScheme: "tomtomgo://", url: "https://www.tomtom.com"),
+        "sygic": NavigationAppInfo(name: "Sygic", urlScheme: "com.sygic.aura://", url: "https://www.sygic.com/gps-navigation"),
+        "here": NavigationAppInfo(name: "HERE Maps", urlScheme: "here-route://", url: "https://wego.here.com"),
+        "moovit": NavigationAppInfo(name: "Moovit", urlScheme: "moovit://", url: "https://moovitapp.com"),
+        "lyft": NavigationAppInfo(name: "Lyft", urlScheme: "lyft://", url: "https://www.lyft.com"),
+        "mapsme": NavigationAppInfo(name: "MAPS.ME", urlScheme: "mapsme://", url: "https://maps.me"),
+        "guru_maps": NavigationAppInfo(name: "Guru Maps", urlScheme: "guru://", url: "https://gurumaps.app"),
+        "organic_maps": NavigationAppInfo(name: "Organic Maps", urlScheme: "om://", url: "https://organicmaps.app"),
+        "yandex_maps": NavigationAppInfo(name: "Yandex Maps", urlScheme: "yandexmaps://", url: "https://yandex.com/maps"),
+        "2gis": NavigationAppInfo(name: "2GIS", urlScheme: "dgis://", url: "https://2gis.com"),
+        "cabify": NavigationAppInfo(name: "Cabify", urlScheme: "cabify://", url: "https://cabify.com"),
+        "baidu": NavigationAppInfo(name: "Baidu Maps", urlScheme: "baidumap://", url: "https://map.baidu.com"),
+        "gaode": NavigationAppInfo(name: "Gaode Maps", urlScheme: "iosamap://", url: "https://www.amap.com"),
+        "tesla": NavigationAppInfo(name: "Tesla", urlScheme: "tesla://", url: "https://www.tesla.com"),
+        "99taxi": NavigationAppInfo(name: "99 Taxi", urlScheme: "99app://", url: "https://99app.com")
     ]
 
+    // swiftlint:disable:next cyclomatic_complexity function_body_length function_parameter_count
     public func navigate(
         app: String,
         destination: CLLocationCoordinate2D,
@@ -32,6 +47,7 @@ import MapKit
         startName: String?,
         destinationName: String?,
         transportMode: String,
+        viewController: UIViewController? = nil,
         completion: @escaping (Bool, String?) -> Void
     ) {
         switch app {
@@ -106,6 +122,34 @@ import MapKit
                 destination: destination,
                 completion: completion
             )
+        case "guru_maps":
+            launchGuruMaps(
+                destination: destination,
+                start: start,
+                transportMode: transportMode,
+                completion: completion
+            )
+        case "organic_maps":
+            launchOrganicMaps(
+                destination: destination,
+                start: start,
+                destinationName: destinationName,
+                transportMode: transportMode,
+                completion: completion
+            )
+        case "yandex_maps":
+            launchYandexMaps(
+                destination: destination,
+                start: start,
+                completion: completion
+            )
+        case "2gis":
+            launch2Gis(
+                destination: destination,
+                start: start,
+                transportMode: transportMode,
+                completion: completion
+            )
         case "cabify":
             launchCabify(
                 destination: destination,
@@ -122,6 +166,14 @@ import MapKit
             launchGaode(
                 destination: destination,
                 start: start,
+                completion: completion
+            )
+        case "tesla":
+            shareToTesla(
+                destination: destination,
+                start: start,
+                transportMode: transportMode,
+                viewController: viewController,
                 completion: completion
             )
         default:
@@ -300,6 +352,103 @@ import MapKit
         openURL(urlString, completion: completion)
     }
 
+    private func launchGuruMaps(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var urlString = "guru://nav?finish=\(destination.latitude),\(destination.longitude)&mode=\(guruMapsMode(transportMode))&start_navigation=true"
+
+        if let startCoord = start {
+            urlString += "&start=\(startCoord.latitude),\(startCoord.longitude)"
+        }
+
+        openURL(urlString, completion: completion)
+    }
+
+    private func guruMapsMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "pedestrian"
+        case "bicycling":
+            return "bicycle"
+        default:
+            return "auto"
+        }
+    }
+
+    private func launchOrganicMaps(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        destinationName: String?,
+        transportMode: String,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        let origin = start.map { "\($0.latitude),\($0.longitude)" } ?? "currentLocation"
+        var urlString = "om://v2/nav?origin=\(encoded(origin))&destination=\(destination.latitude),\(destination.longitude)&mode=\(organicMapsMode(transportMode))"
+
+        if let destinationName = destinationName, !destinationName.isEmpty {
+            urlString += "&destination_name=\(encoded(destinationName))"
+        }
+
+        openURL(urlString, completion: completion)
+    }
+
+    private func organicMapsMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "pedestrian"
+        case "bicycling":
+            return "bicycle"
+        case "transit":
+            return "transit"
+        default:
+            return "drive"
+        }
+    }
+
+    private func launchYandexMaps(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var urlString = "yandexmaps://build_route_on_map/?lat_to=\(destination.latitude)&lon_to=\(destination.longitude)"
+
+        if let startCoord = start {
+            urlString += "&lat_from=\(startCoord.latitude)&lon_from=\(startCoord.longitude)"
+        }
+
+        openURL(urlString, completion: completion)
+    }
+
+    private func launch2Gis(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var urlString = "dgis://2gis.ru/routeSearch/rsType/\(twoGisMode(transportMode))"
+
+        if let startCoord = start {
+            urlString += "/from/\(startCoord.longitude),\(startCoord.latitude)"
+        }
+
+        urlString += "/to/\(destination.longitude),\(destination.latitude)"
+        openURL(urlString, completion: completion)
+    }
+
+    private func twoGisMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "pedestrian"
+        case "transit":
+            return "ctx"
+        default:
+            return "car"
+        }
+    }
+
     private func launchCabify(
         destination: CLLocationCoordinate2D,
         start: CLLocationCoordinate2D?,
@@ -340,6 +489,69 @@ import MapKit
         }
 
         openURL(urlString, completion: completion)
+    }
+
+    private func shareToTesla(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String,
+        viewController: UIViewController?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        guard let viewController = viewController else {
+            completion(false, "Unable to present share sheet")
+            return
+        }
+
+        guard let url = googleMapsWebURL(destination: destination, start: start, transportMode: transportMode) else {
+            completion(false, "Invalid Tesla share URL")
+            return
+        }
+
+        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = viewController.view
+        activityViewController.completionWithItemsHandler = { _, completed, _, error in
+            if let error = error {
+                completion(false, error.localizedDescription)
+            } else if completed {
+                completion(true, nil)
+            } else {
+                completion(false, "Share cancelled")
+            }
+        }
+
+        viewController.present(activityViewController, animated: true)
+    }
+
+    private func googleMapsWebURL(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String
+    ) -> URL? {
+        var urlString = "https://www.google.com/maps/dir/?api=1&destination=\(destination.latitude),\(destination.longitude)&travelmode=\(googleMapsTravelMode(transportMode))"
+
+        if let startCoord = start {
+            urlString += "&origin=\(startCoord.latitude),\(startCoord.longitude)"
+        }
+
+        return URL(string: urlString)
+    }
+
+    private func googleMapsTravelMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "walking"
+        case "bicycling":
+            return "bicycling"
+        case "transit":
+            return "transit"
+        default:
+            return "driving"
+        }
+    }
+
+    private func encoded(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
     }
 
     private func openURL(_ urlString: String, completion: @escaping (Bool, String?) -> Void) {
@@ -392,3 +604,4 @@ import MapKit
         return Array(navigationApps.keys)
     }
 }
+// swiftlint:enable type_body_length

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import MapKit
 
+// swiftlint:disable type_body_length
 @objc public class LaunchNavigator: NSObject {
 
     private let navigationApps: [String: (name: String, urlScheme: String)] = [
@@ -19,12 +20,18 @@ import MapKit
         "moovit": ("Moovit", "moovit://"),
         "lyft": ("Lyft", "lyft://"),
         "mapsme": ("MAPS.ME", "mapsme://"),
+        "guru_maps": ("Guru Maps", "guru://"),
+        "organic_maps": ("Organic Maps", "om://"),
+        "yandex_maps": ("Yandex Maps", "yandexmaps://"),
+        "2gis": ("2GIS", "dgis://"),
         "cabify": ("Cabify", "cabify://"),
         "baidu": ("Baidu Maps", "baidumap://"),
         "gaode": ("Gaode Maps", "iosamap://"),
+        "tesla": ("Tesla", "tesla://"),
         "99taxi": ("99 Taxi", "99app://")
     ]
 
+    // swiftlint:disable:next cyclomatic_complexity function_body_length function_parameter_count
     public func navigate(
         app: String,
         destination: CLLocationCoordinate2D,
@@ -32,6 +39,7 @@ import MapKit
         startName: String?,
         destinationName: String?,
         transportMode: String,
+        viewController: UIViewController? = nil,
         completion: @escaping (Bool, String?) -> Void
     ) {
         switch app {
@@ -106,6 +114,34 @@ import MapKit
                 destination: destination,
                 completion: completion
             )
+        case "guru_maps":
+            launchGuruMaps(
+                destination: destination,
+                start: start,
+                transportMode: transportMode,
+                completion: completion
+            )
+        case "organic_maps":
+            launchOrganicMaps(
+                destination: destination,
+                start: start,
+                destinationName: destinationName,
+                transportMode: transportMode,
+                completion: completion
+            )
+        case "yandex_maps":
+            launchYandexMaps(
+                destination: destination,
+                start: start,
+                completion: completion
+            )
+        case "2gis":
+            launch2Gis(
+                destination: destination,
+                start: start,
+                transportMode: transportMode,
+                completion: completion
+            )
         case "cabify":
             launchCabify(
                 destination: destination,
@@ -122,6 +158,14 @@ import MapKit
             launchGaode(
                 destination: destination,
                 start: start,
+                completion: completion
+            )
+        case "tesla":
+            shareToTesla(
+                destination: destination,
+                start: start,
+                transportMode: transportMode,
+                viewController: viewController,
                 completion: completion
             )
         default:
@@ -300,6 +344,103 @@ import MapKit
         openURL(urlString, completion: completion)
     }
 
+    private func launchGuruMaps(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var urlString = "guru://nav?finish=\(destination.latitude),\(destination.longitude)&mode=\(guruMapsMode(transportMode))&start_navigation=true"
+
+        if let startCoord = start {
+            urlString += "&start=\(startCoord.latitude),\(startCoord.longitude)"
+        }
+
+        openURL(urlString, completion: completion)
+    }
+
+    private func guruMapsMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "pedestrian"
+        case "bicycling":
+            return "bicycle"
+        default:
+            return "auto"
+        }
+    }
+
+    private func launchOrganicMaps(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        destinationName: String?,
+        transportMode: String,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        let origin = start.map { "\($0.latitude),\($0.longitude)" } ?? "currentLocation"
+        var urlString = "om://v2/nav?origin=\(encoded(origin))&destination=\(destination.latitude),\(destination.longitude)&mode=\(organicMapsMode(transportMode))"
+
+        if let destinationName = destinationName, !destinationName.isEmpty {
+            urlString += "&destination_name=\(encoded(destinationName))"
+        }
+
+        openURL(urlString, completion: completion)
+    }
+
+    private func organicMapsMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "pedestrian"
+        case "bicycling":
+            return "bicycle"
+        case "transit":
+            return "transit"
+        default:
+            return "drive"
+        }
+    }
+
+    private func launchYandexMaps(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var urlString = "yandexmaps://build_route_on_map/?lat_to=\(destination.latitude)&lon_to=\(destination.longitude)"
+
+        if let startCoord = start {
+            urlString += "&lat_from=\(startCoord.latitude)&lon_from=\(startCoord.longitude)"
+        }
+
+        openURL(urlString, completion: completion)
+    }
+
+    private func launch2Gis(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var urlString = "dgis://2gis.ru/routeSearch/rsType/\(twoGisMode(transportMode))"
+
+        if let startCoord = start {
+            urlString += "/from/\(startCoord.longitude),\(startCoord.latitude)"
+        }
+
+        urlString += "/to/\(destination.longitude),\(destination.latitude)"
+        openURL(urlString, completion: completion)
+    }
+
+    private func twoGisMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "pedestrian"
+        case "transit":
+            return "ctx"
+        default:
+            return "car"
+        }
+    }
+
     private func launchCabify(
         destination: CLLocationCoordinate2D,
         start: CLLocationCoordinate2D?,
@@ -340,6 +481,69 @@ import MapKit
         }
 
         openURL(urlString, completion: completion)
+    }
+
+    private func shareToTesla(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String,
+        viewController: UIViewController?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        guard let viewController = viewController else {
+            completion(false, "Unable to present share sheet")
+            return
+        }
+
+        guard let url = googleMapsWebURL(destination: destination, start: start, transportMode: transportMode) else {
+            completion(false, "Invalid Tesla share URL")
+            return
+        }
+
+        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = viewController.view
+        activityViewController.completionWithItemsHandler = { _, completed, _, error in
+            if let error = error {
+                completion(false, error.localizedDescription)
+            } else if completed {
+                completion(true, nil)
+            } else {
+                completion(false, "Share cancelled")
+            }
+        }
+
+        viewController.present(activityViewController, animated: true)
+    }
+
+    private func googleMapsWebURL(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        transportMode: String
+    ) -> URL? {
+        var urlString = "https://www.google.com/maps/dir/?api=1&destination=\(destination.latitude),\(destination.longitude)&travelmode=\(googleMapsTravelMode(transportMode))"
+
+        if let startCoord = start {
+            urlString += "&origin=\(startCoord.latitude),\(startCoord.longitude)"
+        }
+
+        return URL(string: urlString)
+    }
+
+    private func googleMapsTravelMode(_ transportMode: String) -> String {
+        switch transportMode {
+        case "walking":
+            return "walking"
+        case "bicycling":
+            return "bicycling"
+        case "transit":
+            return "transit"
+        default:
+            return "driving"
+        }
+    }
+
+    private func encoded(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
     }
 
     private func openURL(_ urlString: String, completion: @escaping (Bool, String?) -> Void) {
@@ -392,3 +596,4 @@ import MapKit
         return Array(navigationApps.keys)
     }
 }
+// swiftlint:enable type_body_length

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
@@ -103,6 +103,7 @@ extension LaunchNavigator {
                 metadata["mimeType"] = mimeType
             }
             try writeMetadata(metadata, app: provider.app)
+            _ = deleteCachedFiles(app: provider.app, keeping: [iconFileURL.lastPathComponent, metadataURL(app: provider.app).lastPathComponent])
             return iconObject(cachedIcon: CachedIcon(fileURL: iconFileURL, metadata: metadata), fromCache: false, stale: false)
         } catch {
             if let cachedIcon = cachedIcon {
@@ -267,11 +268,18 @@ extension LaunchNavigator {
     }
 
     private func writeIcon(app: String, downloadedIcon: DownloadedIcon) throws -> URL {
-        _ = deleteCachedFiles(app: app)
         let fileName = cacheKey(app) + iconExtension(mimeType: downloadedIcon.mimeType, sourceUrl: downloadedIcon.sourceUrl)
-        let fileURL = iconCacheDirectory().appendingPathComponent(fileName)
-        try FileManager.default.createDirectory(at: iconCacheDirectory(), withIntermediateDirectories: true)
-        try downloadedIcon.data.write(to: fileURL, options: .atomic)
+        let directory = iconCacheDirectory()
+        let fileURL = directory.appendingPathComponent(fileName)
+        let tempURL = directory.appendingPathComponent(fileName + ".tmp")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: tempURL)
+        try downloadedIcon.data.write(to: tempURL, options: .atomic)
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            _ = try FileManager.default.replaceItemAt(fileURL, withItemAt: tempURL)
+        } else {
+            try FileManager.default.moveItem(at: tempURL, to: fileURL)
+        }
         return fileURL
     }
 
@@ -308,7 +316,7 @@ extension LaunchNavigator {
         iconCacheDirectory().appendingPathComponent(cacheKey(app) + ".json")
     }
 
-    private func deleteCachedFiles(app: String) -> Int {
+    private func deleteCachedFiles(app: String, keeping keptFileNames: Set<String> = []) -> Int {
         let prefix = cacheKey(app) + "."
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: iconCacheDirectory(),
@@ -318,7 +326,10 @@ extension LaunchNavigator {
         }
 
         var deleted = 0
-        for file in files where file.lastPathComponent.hasPrefix(prefix) && deleteFileIfExists(file) {
+        for file in files
+        where file.lastPathComponent.hasPrefix(prefix) &&
+            !keptFileNames.contains(file.lastPathComponent) &&
+            deleteFileIfExists(file) {
             deleted += 1
         }
         return deleted
@@ -375,16 +386,7 @@ extension LaunchNavigator {
             }
         }
 
-        if !customProviders.isEmpty {
-            return customProviders.compactMap { providerObject in
-                guard let app = providerObject["app"] as? String else {
-                    return nil
-                }
-                return providers[app]
-            }
-        }
-
-        return navigationApps.keys.compactMap { providers[$0] }
+        return providers.keys.compactMap { providers[$0] }
     }
 
     private func normalizeMimeType(_ mimeType: String?) -> String? {

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
@@ -1,0 +1,444 @@
+import Foundation
+
+private let defaultIconCacheMaxAgeMs = 24.0 * 60.0 * 60.0 * 1000.0
+private let iconRequestTimeout: TimeInterval = 8
+private let maxIconBytes = 2 * 1024 * 1024
+private let maxHTMLBytes = 512 * 1024
+private let iconCacheDirectoryName = "LaunchNavigatorIcons"
+
+private struct IconProvider {
+    let app: String
+    let name: String?
+    let url: String?
+    let iconUrl: String?
+}
+
+private struct CachedIcon {
+    let fileURL: URL
+    let metadata: [String: Any]
+}
+
+private struct DownloadedIcon {
+    let data: Data
+    let sourceUrl: String
+    let mimeType: String?
+}
+
+private struct IconDownloadError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+extension LaunchNavigator {
+    func getAppIcons(options: [String: Any], forceRefresh forceRefreshOverride: Bool) -> [String: Any] {
+        let maxAgeMs = maxAge(from: options)
+        let forceRefresh = forceRefreshOverride || (options["forceRefresh"] as? Bool ?? false)
+        var icons: [[String: Any]] = []
+        var failures: [[String: Any]] = []
+
+        for provider in resolveIconProviders(options: options) {
+            do {
+                icons.append(try resolveProviderIcon(provider: provider, maxAgeMs: maxAgeMs, forceRefresh: forceRefresh))
+            } catch {
+                failures.append(iconFailure(provider: provider, error: error))
+            }
+        }
+
+        return [
+            "icons": icons,
+            "failures": failures
+        ]
+    }
+
+    func clearIconCache(options: [String: Any]) -> [String: Any] {
+        var cleared = 0
+
+        if let apps = options["apps"] as? [String], !apps.isEmpty {
+            for app in apps {
+                cleared += deleteCachedFiles(app: app)
+            }
+        } else if let files = try? FileManager.default.contentsOfDirectory(
+            at: iconCacheDirectory(),
+            includingPropertiesForKeys: nil
+        ) {
+            for file in files where deleteFileIfExists(file) {
+                cleared += 1
+            }
+        }
+
+        return ["cleared": cleared]
+    }
+
+    private func resolveProviderIcon(
+        provider: IconProvider,
+        maxAgeMs: Double,
+        forceRefresh: Bool
+    ) throws -> [String: Any] {
+        let cachedIcon = readCachedIcon(app: provider.app)
+        let now = Date().timeIntervalSince1970 * 1000
+
+        if let cachedIcon = cachedIcon,
+           !forceRefresh,
+           let fetchedAt = cachedIcon.metadata["fetchedAt"] as? Double,
+           now - fetchedAt < maxAgeMs {
+            return iconObject(cachedIcon: cachedIcon, fromCache: true, stale: false)
+        }
+
+        do {
+            let downloadedIcon = try downloadIcon(provider: provider)
+            let iconFileURL = try writeIcon(app: provider.app, downloadedIcon: downloadedIcon)
+            var metadata: [String: Any] = [
+                "app": provider.app,
+                "sourceUrl": downloadedIcon.sourceUrl,
+                "fetchedAt": now,
+                "fileName": iconFileURL.lastPathComponent
+            ]
+            if let name = provider.name, !name.isEmpty {
+                metadata["name"] = name
+            }
+            if let mimeType = downloadedIcon.mimeType, !mimeType.isEmpty {
+                metadata["mimeType"] = mimeType
+            }
+            try writeMetadata(metadata, app: provider.app)
+            return iconObject(cachedIcon: CachedIcon(fileURL: iconFileURL, metadata: metadata), fromCache: false, stale: false)
+        } catch {
+            if let cachedIcon = cachedIcon {
+                return iconObject(cachedIcon: cachedIcon, fromCache: true, stale: true)
+            }
+            throw error
+        }
+    }
+
+    private func iconObject(cachedIcon: CachedIcon, fromCache: Bool, stale: Bool) -> [String: Any] {
+        var icon: [String: Any] = [
+            "app": cachedIcon.metadata["app"] as? String ?? "",
+            "localUrl": webPath(for: cachedIcon.fileURL),
+            "sourceUrl": cachedIcon.metadata["sourceUrl"] as? String ?? "",
+            "fetchedAt": cachedIcon.metadata["fetchedAt"] as? Double ?? 0,
+            "fromCache": fromCache,
+            "stale": stale
+        ]
+
+        if let name = cachedIcon.metadata["name"] as? String, !name.isEmpty {
+            icon["name"] = name
+        }
+        if let mimeType = cachedIcon.metadata["mimeType"] as? String, !mimeType.isEmpty {
+            icon["mimeType"] = mimeType
+        }
+
+        return icon
+    }
+
+    private func iconFailure(provider: IconProvider, error: Error) -> [String: Any] {
+        var failure: [String: Any] = [
+            "app": provider.app,
+            "message": error.localizedDescription
+        ]
+
+        if let name = provider.name, !name.isEmpty {
+            failure["name"] = name
+        }
+        if let sourceUrl = provider.iconUrl ?? provider.url, !sourceUrl.isEmpty {
+            failure["sourceUrl"] = sourceUrl
+        }
+
+        return failure
+    }
+
+    private func downloadIcon(provider: IconProvider) throws -> DownloadedIcon {
+        let sourceUrl: URL
+        if let iconUrl = provider.iconUrl, !iconUrl.isEmpty {
+            sourceUrl = try resolvedURL(iconUrl, relativeTo: provider.url)
+        } else {
+            guard let providerUrl = provider.url, !providerUrl.isEmpty else {
+                throw IconDownloadError(message: "Provider url or iconUrl is required")
+            }
+            sourceUrl = try discoverIconURL(providerUrl)
+        }
+
+        let (data, response) = try fetch(sourceUrl, maxBytes: maxIconBytes)
+        let mimeType = normalizeMimeType(response.mimeType)
+        guard isSupportedImageResponse(mimeType: mimeType, sourceUrl: response.url ?? sourceUrl) else {
+            throw IconDownloadError(message: "Icon response is not an image")
+        }
+
+        return DownloadedIcon(data: data, sourceUrl: (response.url ?? sourceUrl).absoluteString, mimeType: mimeType)
+    }
+
+    private func discoverIconURL(_ providerUrl: String) throws -> URL {
+        let pageURL = try resolvedURL(providerUrl, relativeTo: nil)
+        let (data, response) = try fetch(pageURL, maxBytes: maxHTMLBytes)
+        let html = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) ?? ""
+        let baseURL = response.url ?? pageURL
+
+        if let iconPath = firstIconHref(in: html) {
+            return try resolvedURL(iconPath, relativeTo: baseURL.absoluteString)
+        }
+
+        return try resolvedURL("/favicon.ico", relativeTo: baseURL.absoluteString)
+    }
+
+    private func fetch(_ url: URL, maxBytes: Int) throws -> (Data, URLResponse) {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = iconRequestTimeout
+        request.setValue("CapgoLaunchNavigator/8", forHTTPHeaderField: "User-Agent")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<(Data, URLResponse), Error>?
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { semaphore.signal() }
+            result = self.responseResult(data: data, response: response, error: error, maxBytes: maxBytes)
+        }
+        task.resume()
+
+        if semaphore.wait(timeout: .now() + iconRequestTimeout + 2) == .timedOut {
+            task.cancel()
+            throw IconDownloadError(message: "Request timed out")
+        }
+
+        guard let result = result else {
+            throw IconDownloadError(message: "Request failed")
+        }
+        return try result.get()
+    }
+
+    private func responseResult(
+        data: Data?,
+        response: URLResponse?,
+        error: Error?,
+        maxBytes: Int
+    ) -> Result<(Data, URLResponse), Error> {
+        if let error = error {
+            return .failure(error)
+        }
+        guard let data = data, let response = response else {
+            return .failure(IconDownloadError(message: "Empty response"))
+        }
+        guard data.count <= maxBytes else {
+            return .failure(IconDownloadError(message: "Response is too large"))
+        }
+        if let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode < 200 || httpResponse.statusCode >= 300 {
+            return .failure(IconDownloadError(message: "Request failed with status \(httpResponse.statusCode)"))
+        }
+        return .success((data, response))
+    }
+
+    private func firstIconHref(in html: String) -> String? {
+        let linkPattern = #"<link\s+[^>]*rel=["'][^"']*(?:apple-touch-icon|icon)[^"']*["'][^>]*>"#
+        let hrefPattern = #"\shref=["']([^"']+)["']"#
+
+        guard let linkRegex = try? NSRegularExpression(pattern: linkPattern, options: [.caseInsensitive]),
+              let hrefRegex = try? NSRegularExpression(pattern: hrefPattern, options: [.caseInsensitive]) else {
+            return nil
+        }
+
+        let range = NSRange(html.startIndex..<html.endIndex, in: html)
+        guard let linkMatch = linkRegex.firstMatch(in: html, range: range),
+              let linkRange = Range(linkMatch.range, in: html) else {
+            return nil
+        }
+
+        let linkTag = String(html[linkRange])
+        let hrefRange = NSRange(linkTag.startIndex..<linkTag.endIndex, in: linkTag)
+        guard let hrefMatch = hrefRegex.firstMatch(in: linkTag, range: hrefRange),
+              hrefMatch.numberOfRanges > 1,
+              let valueRange = Range(hrefMatch.range(at: 1), in: linkTag) else {
+            return nil
+        }
+
+        return String(linkTag[valueRange])
+    }
+
+    private func resolvedURL(_ value: String, relativeTo baseUrl: String?) throws -> URL {
+        if let baseUrl = baseUrl,
+           let base = URL(string: baseUrl),
+           let url = URL(string: value, relativeTo: base)?.absoluteURL {
+            return url
+        }
+
+        guard let url = URL(string: value) else {
+            throw IconDownloadError(message: "Invalid icon URL: \(value)")
+        }
+        return url
+    }
+
+    private func writeIcon(app: String, downloadedIcon: DownloadedIcon) throws -> URL {
+        _ = deleteCachedFiles(app: app)
+        let fileName = cacheKey(app) + iconExtension(mimeType: downloadedIcon.mimeType, sourceUrl: downloadedIcon.sourceUrl)
+        let fileURL = iconCacheDirectory().appendingPathComponent(fileName)
+        try FileManager.default.createDirectory(at: iconCacheDirectory(), withIntermediateDirectories: true)
+        try downloadedIcon.data.write(to: fileURL, options: .atomic)
+        return fileURL
+    }
+
+    private func readCachedIcon(app: String) -> CachedIcon? {
+        let metadataURL = metadataURL(app: app)
+        guard let data = try? Data(contentsOf: metadataURL),
+              let metadata = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let fileName = metadata["fileName"] as? String else {
+            return nil
+        }
+
+        let fileURL = iconCacheDirectory().appendingPathComponent(fileName)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        return CachedIcon(fileURL: fileURL, metadata: metadata)
+    }
+
+    private func writeMetadata(_ metadata: [String: Any], app: String) throws {
+        let data = try JSONSerialization.data(withJSONObject: metadata)
+        try FileManager.default.createDirectory(at: iconCacheDirectory(), withIntermediateDirectories: true)
+        try data.write(to: metadataURL(app: app), options: .atomic)
+    }
+
+    private func iconCacheDirectory() -> URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0].appendingPathComponent(
+            iconCacheDirectoryName,
+            isDirectory: true
+        )
+    }
+
+    private func metadataURL(app: String) -> URL {
+        iconCacheDirectory().appendingPathComponent(cacheKey(app) + ".json")
+    }
+
+    private func deleteCachedFiles(app: String) -> Int {
+        let prefix = cacheKey(app) + "."
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: iconCacheDirectory(),
+            includingPropertiesForKeys: nil
+        ) else {
+            return 0
+        }
+
+        var deleted = 0
+        for file in files where file.lastPathComponent.hasPrefix(prefix) && deleteFileIfExists(file) {
+            deleted += 1
+        }
+        return deleted
+    }
+
+    private func deleteFileIfExists(_ fileURL: URL) -> Bool {
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private func webPath(for fileURL: URL) -> String {
+        webPathResolver?(fileURL) ?? fileURL.absoluteString
+    }
+
+    private func maxAge(from options: [String: Any]) -> Double {
+        if let value = options["maxAgeMs"] as? Double, value >= 0 {
+            return value
+        }
+        if let value = options["maxAgeMs"] as? NSNumber, value.doubleValue >= 0 {
+            return value.doubleValue
+        }
+        return defaultIconCacheMaxAgeMs
+    }
+
+    private func resolveIconProviders(options: [String: Any]) -> [IconProvider] {
+        var providers: [String: IconProvider] = [:]
+
+        for (app, appInfo) in navigationApps {
+            providers[app] = IconProvider(app: app, name: appInfo.name, url: appInfo.url, iconUrl: nil)
+        }
+
+        let customProviders = options["providers"] as? [[String: Any]] ?? []
+        for providerObject in customProviders {
+            guard let app = providerObject["app"] as? String, !app.isEmpty else {
+                continue
+            }
+
+            let existing = providers[app]
+            providers[app] = IconProvider(
+                app: app,
+                name: providerObject["name"] as? String ?? existing?.name,
+                url: providerObject["url"] as? String ?? existing?.url,
+                iconUrl: providerObject["iconUrl"] as? String ?? existing?.iconUrl
+            )
+        }
+
+        if let apps = options["apps"] as? [String], !apps.isEmpty {
+            return apps.map { app in
+                providers[app] ?? IconProvider(app: app, name: nil, url: nil, iconUrl: nil)
+            }
+        }
+
+        if !customProviders.isEmpty {
+            return customProviders.compactMap { providerObject in
+                guard let app = providerObject["app"] as? String else {
+                    return nil
+                }
+                return providers[app]
+            }
+        }
+
+        return navigationApps.keys.compactMap { providers[$0] }
+    }
+
+    private func normalizeMimeType(_ mimeType: String?) -> String? {
+        mimeType?.components(separatedBy: ";").first?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func isSupportedImageResponse(mimeType: String?, sourceUrl: URL) -> Bool {
+        guard let mimeType = mimeType, !mimeType.isEmpty else {
+            return hasKnownImageExtension(sourceUrl)
+        }
+
+        return mimeType.hasPrefix("image/") || (mimeType == "application/octet-stream" && hasKnownImageExtension(sourceUrl))
+    }
+
+    private func hasKnownImageExtension(_ sourceUrl: URL) -> Bool {
+        let path = sourceUrl.path.lowercased()
+        return [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"].contains { path.hasSuffix($0) }
+    }
+
+    private func iconExtension(mimeType: String?, sourceUrl: String) -> String {
+        switch mimeType {
+        case "image/jpeg":
+            return ".jpg"
+        case "image/png":
+            return ".png"
+        case "image/gif":
+            return ".gif"
+        case "image/webp":
+            return ".webp"
+        case "image/svg+xml":
+            return ".svg"
+        case "image/x-icon", "image/vnd.microsoft.icon":
+            return ".ico"
+        default:
+            let lowerUrl = sourceUrl.lowercased()
+            for ext in [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico"] where lowerUrl.hasSuffix(ext) {
+                return ext == ".jpeg" ? ".jpg" : ext
+            }
+            return ".img"
+        }
+    }
+
+    private func cacheKey(_ app: String) -> String {
+        let safeApp = app.map { character in
+            character.isLetter || character.isNumber || character == "." || character == "_" || character == "-" ? character : "_"
+        }
+        return String(safeApp) + "_" + stableHash(app)
+    }
+
+    private func stableHash(_ value: String) -> String {
+        var hash: UInt64 = 5381
+        for byte in value.utf8 {
+            hash = ((hash << 5) &+ hash) &+ UInt64(byte)
+        }
+        return String(format: "%016llx", hash)
+    }
+}

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
@@ -58,7 +58,7 @@ extension LaunchNavigator {
 
         if let apps = options["apps"] as? [String], !apps.isEmpty {
             for app in apps {
-                cleared += deleteCachedFiles(app: app)
+                cleared += deleteCachedFiles(app: app) ? 1 : 0
             }
         } else if let files = try? FileManager.default.contentsOfDirectory(
             at: iconCacheDirectory(),
@@ -316,21 +316,22 @@ extension LaunchNavigator {
         iconCacheDirectory().appendingPathComponent(cacheKey(app) + ".json")
     }
 
-    private func deleteCachedFiles(app: String, keeping keptFileNames: Set<String> = []) -> Int {
+    @discardableResult
+    private func deleteCachedFiles(app: String, keeping keptFileNames: Set<String> = []) -> Bool {
         let prefix = cacheKey(app) + "."
         guard let files = try? FileManager.default.contentsOfDirectory(
             at: iconCacheDirectory(),
             includingPropertiesForKeys: nil
         ) else {
-            return 0
+            return false
         }
 
-        var deleted = 0
+        var deleted = false
         for file in files
         where file.lastPathComponent.hasPrefix(prefix) &&
             !keptFileNames.contains(file.lastPathComponent) &&
             deleteFileIfExists(file) {
-            deleted += 1
+            deleted = true
         }
         return deleted
     }

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorPlugin.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorPlugin.swift
@@ -24,6 +24,7 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = LaunchNavigator()
+    private let iconCacheQueue = DispatchQueue(label: "app.capgo.plugin.launch_navigator.icons")
 
     override public func load() {
         super.load()
@@ -110,7 +111,7 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func getAppIcons(_ call: CAPPluginCall) {
         let options = call.options as? [String: Any] ?? [:]
-        DispatchQueue.global(qos: .utility).async {
+        iconCacheQueue.async {
             let result = self.implementation.getAppIcons(options: options, forceRefresh: false)
             DispatchQueue.main.async {
                 call.resolve(result)
@@ -120,7 +121,7 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func refreshAppIcons(_ call: CAPPluginCall) {
         let options = call.options as? [String: Any] ?? [:]
-        DispatchQueue.global(qos: .utility).async {
+        iconCacheQueue.async {
             let result = self.implementation.getAppIcons(options: options, forceRefresh: true)
             DispatchQueue.main.async {
                 call.resolve(result)
@@ -130,7 +131,7 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func clearIconCache(_ call: CAPPluginCall) {
         let options = call.options as? [String: Any] ?? [:]
-        DispatchQueue.global(qos: .utility).async {
+        iconCacheQueue.async {
             let result = self.implementation.clearIconCache(options: options)
             DispatchQueue.main.async {
                 call.resolve(result)

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorPlugin.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorPlugin.swift
@@ -18,9 +18,22 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getAvailableApps", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getSupportedApps", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getDefaultApp", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getAppIcons", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "refreshAppIcons", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clearIconCache", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = LaunchNavigator()
+
+    override public func load() {
+        super.load()
+        implementation.webPathResolver = { [weak self] localURL in
+            guard let portable = self?.bridge?.portablePath(fromLocalURL: localURL) else {
+                return nil
+            }
+            return portable.absoluteString
+        }
+    }
 
     @objc func navigate(_ call: CAPPluginCall) {
         guard let destination = call.getArray("destination") as? [Double],
@@ -51,7 +64,8 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
                 start: start,
                 startName: startName,
                 destinationName: destinationName,
-                transportMode: transportMode
+                transportMode: transportMode,
+                viewController: self.bridge?.viewController
             ) { success, error in
                 if success {
                     call.resolve()
@@ -92,6 +106,36 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
         call.resolve([
             "app": "apple_maps"
         ])
+    }
+
+    @objc func getAppIcons(_ call: CAPPluginCall) {
+        let options = call.options as? [String: Any] ?? [:]
+        DispatchQueue.global(qos: .utility).async {
+            let result = self.implementation.getAppIcons(options: options, forceRefresh: false)
+            DispatchQueue.main.async {
+                call.resolve(result)
+            }
+        }
+    }
+
+    @objc func refreshAppIcons(_ call: CAPPluginCall) {
+        let options = call.options as? [String: Any] ?? [:]
+        DispatchQueue.global(qos: .utility).async {
+            let result = self.implementation.getAppIcons(options: options, forceRefresh: true)
+            DispatchQueue.main.async {
+                call.resolve(result)
+            }
+        }
+    }
+
+    @objc func clearIconCache(_ call: CAPPluginCall) {
+        let options = call.options as? [String: Any] ?? [:]
+        DispatchQueue.global(qos: .utility).async {
+            let result = self.implementation.clearIconCache(options: options)
+            DispatchQueue.main.async {
+                call.resolve(result)
+            }
+        }
     }
 
     @objc func getPluginVersion(_ call: CAPPluginCall) {

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorPlugin.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorPlugin.swift
@@ -51,7 +51,8 @@ public class LaunchNavigatorPlugin: CAPPlugin, CAPBridgedPlugin {
                 start: start,
                 startName: startName,
                 destinationName: destinationName,
-                transportMode: transportMode
+                transportMode: transportMode,
+                viewController: self.bridge?.viewController
             ) { success, error in
                 if success {
                     call.resolve()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -16,9 +16,14 @@ export enum IOSNavigationApp {
   MOOVIT = 'moovit',
   LYFT = 'lyft',
   MAPS_ME = 'mapsme',
+  GURU_MAPS = 'guru_maps',
+  ORGANIC_MAPS = 'organic_maps',
+  YANDEX_MAPS = 'yandex_maps',
+  TWO_GIS = '2gis',
   CABIFY = 'cabify',
   BAIDU = 'baidu',
   GAODE = 'gaode',
+  TESLA = 'tesla',
   TAXI_99 = '99taxi',
 }
 
@@ -36,9 +41,16 @@ export enum AndroidNavigationApp {
   MOOVIT = 'moovit',
   LYFT = 'lyft',
   MAPS_ME = 'mapsme',
+  TOMTOM = 'tomtom',
+  GURU_MAPS = 'guru_maps',
+  ORGANIC_MAPS = 'organic_maps',
+  YANDEX_MAPS = 'yandex_maps',
+  MAPY = 'mapy',
+  TWO_GIS = '2gis',
   CABIFY = 'cabify',
   BAIDU = 'baidu',
   GAODE = 'gaode',
+  TESLA = 'tesla',
 }
 
 /**
@@ -126,6 +138,151 @@ export interface AvailableApp {
 }
 
 /**
+ * Web source used to discover or download a provider icon.
+ */
+export interface IconProvider {
+  /**
+   * Navigation app identifier
+   */
+  app: IOSNavigationApp | AndroidNavigationApp | string;
+
+  /**
+   * Display name for the provider
+   */
+  name?: string;
+
+  /**
+   * Provider website used to discover favicon metadata
+   */
+  url?: string;
+
+  /**
+   * Direct image URL. When provided, the plugin downloads this URL instead of discovering a favicon from `url`.
+   */
+  iconUrl?: string;
+}
+
+/**
+ * Options for fetching navigation provider icons.
+ */
+export interface GetAppIconsOptions {
+  /**
+   * App identifiers to fetch. Defaults to all built-in providers for the current platform.
+   */
+  apps?: (IOSNavigationApp | AndroidNavigationApp | string)[];
+
+  /**
+   * Provider definitions to fetch or override built-in provider websites.
+   */
+  providers?: IconProvider[];
+
+  /**
+   * Cache revalidation interval in milliseconds. Defaults to 24 hours.
+   */
+  maxAgeMs?: number;
+
+  /**
+   * Ignore the current cache and fetch icons again.
+   */
+  forceRefresh?: boolean;
+}
+
+/**
+ * Cached icon for a navigation provider.
+ */
+export interface ProviderIcon {
+  /**
+   * Navigation app identifier
+   */
+  app: string;
+
+  /**
+   * Display name for the provider
+   */
+  name?: string;
+
+  /**
+   * URL that can be used directly in an image element inside the WebView.
+   */
+  localUrl: string;
+
+  /**
+   * Web URL used to download the cached image
+   */
+  sourceUrl: string;
+
+  /**
+   * MIME type reported for the cached image, when known
+   */
+  mimeType?: string;
+
+  /**
+   * Unix timestamp in milliseconds when the icon was last fetched
+   */
+  fetchedAt: number;
+
+  /**
+   * Whether the icon came from the local cache without a network refresh
+   */
+  fromCache: boolean;
+
+  /**
+   * Whether a stale cached icon was returned because refresh failed
+   */
+  stale: boolean;
+}
+
+/**
+ * Icon fetch failure for a provider.
+ */
+export interface ProviderIconFailure {
+  /**
+   * Navigation app identifier
+   */
+  app: string;
+
+  /**
+   * Display name for the provider
+   */
+  name?: string;
+
+  /**
+   * Web URL that failed, when known
+   */
+  sourceUrl?: string;
+
+  /**
+   * Failure message
+   */
+  message: string;
+}
+
+/**
+ * Result of fetching provider icons.
+ */
+export interface ProviderIconsResult {
+  /**
+   * Icons available from cache or freshly downloaded
+   */
+  icons: ProviderIcon[];
+
+  /**
+   * Providers that could not be fetched and had no cached fallback
+   */
+  failures: ProviderIconFailure[];
+}
+
+/**
+ * Options for clearing cached provider icons.
+ */
+export interface ClearIconCacheOptions {
+  /**
+   * App identifiers to clear. Defaults to all cached icons.
+   */
+  apps?: (IOSNavigationApp | AndroidNavigationApp | string)[];
+}
+
+/**
  * Main plugin interface
  */
 export interface LaunchNavigatorPlugin {
@@ -189,6 +346,29 @@ export interface LaunchNavigatorPlugin {
      * Default app identifier
      */
     app: string;
+  }>;
+
+  /**
+   * Fetch provider icons and cache them locally.
+   *
+   * The native implementations revalidate cached icons after 24 hours by default.
+   * Pass `forceRefresh: true` to bypass the cache when an icon must be repaired.
+   */
+  getAppIcons(options?: GetAppIconsOptions): Promise<ProviderIconsResult>;
+
+  /**
+   * Refresh provider icons, ignoring the cache age.
+   */
+  refreshAppIcons(options?: GetAppIconsOptions): Promise<ProviderIconsResult>;
+
+  /**
+   * Clear cached provider icons.
+   */
+  clearIconCache(options?: ClearIconCacheOptions): Promise<{
+    /**
+     * Number of cached icon files removed
+     */
+    cleared: number;
   }>;
 
   /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -16,9 +16,14 @@ export enum IOSNavigationApp {
   MOOVIT = 'moovit',
   LYFT = 'lyft',
   MAPS_ME = 'mapsme',
+  GURU_MAPS = 'guru_maps',
+  ORGANIC_MAPS = 'organic_maps',
+  YANDEX_MAPS = 'yandex_maps',
+  TWO_GIS = '2gis',
   CABIFY = 'cabify',
   BAIDU = 'baidu',
   GAODE = 'gaode',
+  TESLA = 'tesla',
   TAXI_99 = '99taxi',
 }
 
@@ -36,9 +41,16 @@ export enum AndroidNavigationApp {
   MOOVIT = 'moovit',
   LYFT = 'lyft',
   MAPS_ME = 'mapsme',
+  TOMTOM = 'tomtom',
+  GURU_MAPS = 'guru_maps',
+  ORGANIC_MAPS = 'organic_maps',
+  YANDEX_MAPS = 'yandex_maps',
+  MAPY = 'mapy',
+  TWO_GIS = '2gis',
   CABIFY = 'cabify',
   BAIDU = 'baidu',
   GAODE = 'gaode',
+  TESLA = 'tesla',
 }
 
 /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -354,6 +354,42 @@ export interface LaunchNavigatorPlugin {
    * The native implementations revalidate cached icons after 24 hours by default.
    * Pass `forceRefresh: true` to bypass the cache when an icon must be repaired.
    */
+  getAppIcons?(options?: GetAppIconsOptions): Promise<ProviderIconsResult>;
+
+  /**
+   * Refresh provider icons, ignoring the cache age.
+   */
+  refreshAppIcons?(options?: GetAppIconsOptions): Promise<ProviderIconsResult>;
+
+  /**
+   * Clear cached provider icons.
+   */
+  clearIconCache?(options?: ClearIconCacheOptions): Promise<{
+    /**
+     * Number of cached icon files removed
+     */
+    cleared: number;
+  }>;
+
+  /**
+   * Get the native Capacitor plugin version
+   *
+   * @returns {Promise<{ id: string }>} an Promise with version for this device
+   * @throws An error if the something went wrong
+   */
+  getPluginVersion(): Promise<{ version: string }>;
+}
+
+/**
+ * Required icon cache helpers exposed by the bundled plugin export.
+ */
+export interface LaunchNavigatorPluginIcons {
+  /**
+   * Fetch provider icons and cache them locally.
+   *
+   * The native implementations revalidate cached icons after 24 hours by default.
+   * Pass `forceRefresh: true` to bypass the cache when an icon must be repaired.
+   */
   getAppIcons(options?: GetAppIconsOptions): Promise<ProviderIconsResult>;
 
   /**
@@ -370,12 +406,4 @@ export interface LaunchNavigatorPlugin {
      */
     cleared: number;
   }>;
-
-  /**
-   * Get the native Capacitor plugin version
-   *
-   * @returns {Promise<{ id: string }>} an Promise with version for this device
-   * @throws An error if the something went wrong
-   */
-  getPluginVersion(): Promise<{ version: string }>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { registerPlugin } from '@capacitor/core';
 
-import type { LaunchNavigatorPlugin } from './definitions';
+import type { LaunchNavigatorPlugin, LaunchNavigatorPluginIcons } from './definitions';
 
-const LaunchNavigator = registerPlugin<LaunchNavigatorPlugin>('LaunchNavigator', {
+const LaunchNavigator = registerPlugin<LaunchNavigatorPlugin & LaunchNavigatorPluginIcons>('LaunchNavigator', {
   web: () => import('./web').then((m) => new m.LaunchNavigatorWeb()),
 });
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,62 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { LaunchNavigatorPlugin, NavigateOptions, AvailableApp } from './definitions';
+import type {
+  LaunchNavigatorPlugin,
+  NavigateOptions,
+  AvailableApp,
+  GetAppIconsOptions,
+  ProviderIcon,
+  ProviderIconFailure,
+  ProviderIconsResult,
+  IconProvider,
+  ClearIconCacheOptions,
+} from './definitions';
+
+const DEFAULT_ICON_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const ICON_CACHE_NAME = 'capgo-launch-navigator-icons';
+const ICON_METADATA_PREFIX = 'capgo-launch-navigator-icon:';
+
+const BUILT_IN_ICON_PROVIDERS: IconProvider[] = [
+  { app: 'google_maps', name: 'Google Maps', url: 'https://www.google.com/maps' },
+  { app: 'waze', name: 'Waze', url: 'https://www.waze.com' },
+  { app: 'citymapper', name: 'Citymapper', url: 'https://citymapper.com' },
+  { app: 'uber', name: 'Uber', url: 'https://www.uber.com' },
+  { app: 'yandex', name: 'Yandex Navigator', url: 'https://yandex.com/maps' },
+  { app: 'sygic', name: 'Sygic', url: 'https://www.sygic.com/gps-navigation' },
+  { app: 'here', name: 'HERE Maps', url: 'https://wego.here.com' },
+  { app: 'moovit', name: 'Moovit', url: 'https://moovitapp.com' },
+  { app: 'lyft', name: 'Lyft', url: 'https://www.lyft.com' },
+  { app: 'mapsme', name: 'MAPS.ME', url: 'https://maps.me' },
+  { app: 'guru_maps', name: 'Guru Maps', url: 'https://gurumaps.app' },
+  { app: 'organic_maps', name: 'Organic Maps', url: 'https://organicmaps.app' },
+  { app: 'yandex_maps', name: 'Yandex Maps', url: 'https://yandex.com/maps' },
+  { app: 'mapy', name: 'Mapy.com', url: 'https://mapy.com' },
+  { app: '2gis', name: '2GIS', url: 'https://2gis.com' },
+  { app: 'cabify', name: 'Cabify', url: 'https://cabify.com' },
+  { app: 'baidu', name: 'Baidu Maps', url: 'https://map.baidu.com' },
+  { app: 'gaode', name: 'Gaode Maps', url: 'https://www.amap.com' },
+  { app: 'tesla', name: 'Tesla', url: 'https://www.tesla.com' },
+  { app: 'apple_maps', name: 'Apple Maps', url: 'https://www.apple.com/maps/' },
+  { app: 'tomtom', name: 'TomTom', url: 'https://www.tomtom.com' },
+  { app: 'transit_app', name: 'Transit App', url: 'https://transitapp.com' },
+  { app: 'garmin_navigon', name: 'Garmin Navigon', url: 'https://www.garmin.com' },
+  { app: '99taxi', name: '99 Taxi', url: 'https://99app.com' },
+];
+
+interface StoredIconMetadata {
+  app: string;
+  name?: string;
+  sourceUrl: string;
+  mimeType?: string;
+  fetchedAt: number;
+}
+
+interface CachedWebIcon {
+  metadata: StoredIconMetadata;
+  localUrl: string;
+}
+
+const objectUrls = new Map<string, string>();
 
 export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlugin {
   /**
@@ -81,7 +137,271 @@ export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlug
     };
   }
 
+  async getAppIcons(options: GetAppIconsOptions = {}): Promise<ProviderIconsResult> {
+    const providers = resolveIconProviders(options);
+    const maxAgeMs = normalizeMaxAge(options.maxAgeMs);
+    const forceRefresh = options.forceRefresh === true;
+    const icons: ProviderIcon[] = [];
+    const failures: ProviderIconFailure[] = [];
+
+    await Promise.all(
+      providers.map(async (provider) => {
+        try {
+          icons.push(await this.getProviderIcon(provider, maxAgeMs, forceRefresh));
+        } catch (error) {
+          failures.push({
+            app: String(provider.app),
+            name: provider.name,
+            sourceUrl: provider.iconUrl || provider.url,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }),
+    );
+
+    return { icons, failures };
+  }
+
+  async refreshAppIcons(options: GetAppIconsOptions = {}): Promise<ProviderIconsResult> {
+    return this.getAppIcons({ ...options, forceRefresh: true });
+  }
+
+  async clearIconCache(options: ClearIconCacheOptions = {}): Promise<{ cleared: number }> {
+    const appIds = options.apps?.map(String);
+    const cache = await getCache();
+    let cleared = 0;
+
+    if (appIds && appIds.length > 0) {
+      for (const app of appIds) {
+        cleared += (await deleteCachedIcon(app, cache)) ? 1 : 0;
+      }
+      return { cleared };
+    }
+
+    const storedApps = getStoredAppIds();
+    for (const app of storedApps) {
+      cleared += (await deleteCachedIcon(app, cache)) ? 1 : 0;
+    }
+
+    return { cleared };
+  }
+
   async getPluginVersion(): Promise<{ version: string }> {
     return { version: 'web' };
   }
+
+  private async getProviderIcon(
+    provider: IconProvider,
+    maxAgeMs: number,
+    forceRefresh: boolean,
+  ): Promise<ProviderIcon> {
+    const app = String(provider.app);
+    const cached = await readCachedIcon(app);
+    const now = Date.now();
+
+    if (cached && !forceRefresh && now - cached.metadata.fetchedAt < maxAgeMs) {
+      return toProviderIcon(cached, true, false);
+    }
+
+    try {
+      const sourceUrl = await discoverIconUrl(provider);
+      const response = await fetch(sourceUrl);
+      if (!response.ok) {
+        throw new Error(`Icon request failed with status ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      const mimeType = blob.type || response.headers.get('content-type') || undefined;
+      const cache = await getCache();
+      const metadata: StoredIconMetadata = {
+        app,
+        name: provider.name,
+        sourceUrl,
+        mimeType,
+        fetchedAt: now,
+      };
+      const localUrl = URL.createObjectURL(blob);
+      setObjectUrl(app, localUrl);
+
+      if (cache) {
+        await cache.put(
+          cacheRequest(app),
+          new Response(blob, { headers: mimeType ? { 'content-type': mimeType } : undefined }),
+        );
+      }
+      writeMetadata(metadata);
+
+      return {
+        app,
+        name: metadata.name,
+        localUrl,
+        sourceUrl,
+        mimeType,
+        fetchedAt: metadata.fetchedAt,
+        fromCache: false,
+        stale: false,
+      };
+    } catch (error) {
+      if (cached) {
+        return toProviderIcon(cached, true, true);
+      }
+      throw error;
+    }
+  }
+}
+
+function resolveIconProviders(options: GetAppIconsOptions): IconProvider[] {
+  const builtIns = new Map(BUILT_IN_ICON_PROVIDERS.map((provider) => [String(provider.app), provider]));
+  const customProviders = options.providers || [];
+
+  for (const provider of customProviders) {
+    const app = String(provider.app);
+    builtIns.set(app, { ...builtIns.get(app), ...provider, app });
+  }
+
+  if (options.apps && options.apps.length > 0) {
+    return options.apps.map((app) => builtIns.get(String(app)) || { app: String(app) });
+  }
+
+  if (customProviders.length > 0) {
+    return customProviders.map((provider) => builtIns.get(String(provider.app)) || provider);
+  }
+
+  return [builtIns.get('google_maps') as IconProvider];
+}
+
+function normalizeMaxAge(maxAgeMs: number | undefined): number {
+  if (typeof maxAgeMs !== 'number' || !Number.isFinite(maxAgeMs) || maxAgeMs < 0) {
+    return DEFAULT_ICON_CACHE_MAX_AGE_MS;
+  }
+  return maxAgeMs;
+}
+
+async function discoverIconUrl(provider: IconProvider): Promise<string> {
+  if (provider.iconUrl) {
+    return absolutizeUrl(provider.iconUrl, provider.url);
+  }
+
+  if (!provider.url) {
+    throw new Error('Provider url or iconUrl is required');
+  }
+
+  const response = await fetch(provider.url);
+  if (!response.ok) {
+    throw new Error(`Provider page request failed with status ${response.status}`);
+  }
+
+  const html = await response.text();
+  const linkMatch = html.match(/<link\s+[^>]*rel=["'][^"']*(?:apple-touch-icon|icon)[^"']*["'][^>]*>/i);
+  const href = linkMatch?.[0].match(/\shref=["']([^"']+)["']/i)?.[1];
+
+  if (href) {
+    return absolutizeUrl(href, provider.url);
+  }
+
+  return absolutizeUrl('/favicon.ico', provider.url);
+}
+
+function absolutizeUrl(url: string, baseUrl?: string): string {
+  try {
+    return new URL(url, baseUrl).toString();
+  } catch {
+    throw new Error(`Invalid icon URL: ${url}`);
+  }
+}
+
+async function readCachedIcon(app: string): Promise<CachedWebIcon | undefined> {
+  const metadata = readMetadata(app);
+  const cachedObjectUrl = objectUrls.get(app);
+
+  if (!metadata) {
+    return undefined;
+  }
+
+  if (cachedObjectUrl) {
+    return { metadata, localUrl: cachedObjectUrl };
+  }
+
+  const cache = await getCache();
+  const response = await cache?.match(cacheRequest(app));
+  if (!response) {
+    return undefined;
+  }
+
+  const blob = await response.blob();
+  const localUrl = URL.createObjectURL(blob);
+  setObjectUrl(app, localUrl);
+  return { metadata, localUrl };
+}
+
+function toProviderIcon(cached: CachedWebIcon, fromCache: boolean, stale: boolean): ProviderIcon {
+  return {
+    app: cached.metadata.app,
+    name: cached.metadata.name,
+    localUrl: cached.localUrl,
+    sourceUrl: cached.metadata.sourceUrl,
+    mimeType: cached.metadata.mimeType,
+    fetchedAt: cached.metadata.fetchedAt,
+    fromCache,
+    stale,
+  };
+}
+
+async function getCache(): Promise<Cache | undefined> {
+  if (!('caches' in window)) {
+    return undefined;
+  }
+  return caches.open(ICON_CACHE_NAME);
+}
+
+function cacheRequest(app: string): Request {
+  return new Request(`https://capgo.local/launch-navigator-icons/${encodeURIComponent(app)}`);
+}
+
+function readMetadata(app: string): StoredIconMetadata | undefined {
+  try {
+    const raw = localStorage.getItem(metadataKey(app));
+    return raw ? (JSON.parse(raw) as StoredIconMetadata) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeMetadata(metadata: StoredIconMetadata): void {
+  localStorage.setItem(metadataKey(metadata.app), JSON.stringify(metadata));
+}
+
+function getStoredAppIds(): string[] {
+  const apps: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(ICON_METADATA_PREFIX)) {
+      apps.push(key.slice(ICON_METADATA_PREFIX.length));
+    }
+  }
+  return apps;
+}
+
+async function deleteCachedIcon(app: string, cache: Cache | undefined): Promise<boolean> {
+  const hadMetadata = localStorage.getItem(metadataKey(app)) !== null;
+  localStorage.removeItem(metadataKey(app));
+  const objectUrl = objectUrls.get(app);
+  if (objectUrl) {
+    URL.revokeObjectURL(objectUrl);
+    objectUrls.delete(app);
+  }
+  const deletedFromCache = (await cache?.delete(cacheRequest(app))) || false;
+  return hadMetadata || deletedFromCache;
+}
+
+function metadataKey(app: string): string {
+  return `${ICON_METADATA_PREFIX}${app}`;
+}
+
+function setObjectUrl(app: string, url: string): void {
+  const existing = objectUrls.get(app);
+  if (existing) {
+    URL.revokeObjectURL(existing);
+  }
+  objectUrls.set(app, url);
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,6 +10,7 @@ import type {
   ProviderIconsResult,
   IconProvider,
   ClearIconCacheOptions,
+  LaunchNavigatorPluginIcons,
 } from './definitions';
 
 const DEFAULT_ICON_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -17,31 +18,40 @@ const ICON_CACHE_NAME = 'capgo-launch-navigator-icons';
 const ICON_METADATA_PREFIX = 'capgo-launch-navigator-icon:';
 
 const BUILT_IN_ICON_PROVIDERS: IconProvider[] = [
-  { app: 'google_maps', name: 'Google Maps', url: 'https://www.google.com/maps' },
-  { app: 'waze', name: 'Waze', url: 'https://www.waze.com' },
-  { app: 'citymapper', name: 'Citymapper', url: 'https://citymapper.com' },
-  { app: 'uber', name: 'Uber', url: 'https://www.uber.com' },
-  { app: 'yandex', name: 'Yandex Navigator', url: 'https://yandex.com/maps' },
-  { app: 'sygic', name: 'Sygic', url: 'https://www.sygic.com/gps-navigation' },
-  { app: 'here', name: 'HERE Maps', url: 'https://wego.here.com' },
-  { app: 'moovit', name: 'Moovit', url: 'https://moovitapp.com' },
-  { app: 'lyft', name: 'Lyft', url: 'https://www.lyft.com' },
-  { app: 'mapsme', name: 'MAPS.ME', url: 'https://maps.me' },
-  { app: 'guru_maps', name: 'Guru Maps', url: 'https://gurumaps.app' },
-  { app: 'organic_maps', name: 'Organic Maps', url: 'https://organicmaps.app' },
-  { app: 'yandex_maps', name: 'Yandex Maps', url: 'https://yandex.com/maps' },
-  { app: 'mapy', name: 'Mapy.com', url: 'https://mapy.com' },
-  { app: '2gis', name: '2GIS', url: 'https://2gis.com' },
-  { app: 'cabify', name: 'Cabify', url: 'https://cabify.com' },
-  { app: 'baidu', name: 'Baidu Maps', url: 'https://map.baidu.com' },
-  { app: 'gaode', name: 'Gaode Maps', url: 'https://www.amap.com' },
-  { app: 'tesla', name: 'Tesla', url: 'https://www.tesla.com' },
-  { app: 'apple_maps', name: 'Apple Maps', url: 'https://www.apple.com/maps/' },
-  { app: 'tomtom', name: 'TomTom', url: 'https://www.tomtom.com' },
-  { app: 'transit_app', name: 'Transit App', url: 'https://transitapp.com' },
-  { app: 'garmin_navigon', name: 'Garmin Navigon', url: 'https://www.garmin.com' },
-  { app: '99taxi', name: '99 Taxi', url: 'https://99app.com' },
+  iconProvider('google_maps', 'Google Maps', 'https://www.google.com/maps'),
+  iconProvider('waze', 'Waze', 'https://www.waze.com'),
+  iconProvider('citymapper', 'Citymapper', 'https://citymapper.com'),
+  iconProvider('uber', 'Uber', 'https://www.uber.com'),
+  iconProvider('yandex', 'Yandex Navigator', 'https://yandex.com/maps'),
+  iconProvider('sygic', 'Sygic', 'https://www.sygic.com/gps-navigation'),
+  iconProvider('here', 'HERE Maps', 'https://wego.here.com'),
+  iconProvider('moovit', 'Moovit', 'https://moovitapp.com'),
+  iconProvider('lyft', 'Lyft', 'https://www.lyft.com'),
+  iconProvider('mapsme', 'MAPS.ME', 'https://maps.me'),
+  iconProvider('guru_maps', 'Guru Maps', 'https://gurumaps.app'),
+  iconProvider('organic_maps', 'Organic Maps', 'https://organicmaps.app'),
+  iconProvider('yandex_maps', 'Yandex Maps', 'https://yandex.com/maps'),
+  iconProvider('mapy', 'Mapy.com', 'https://mapy.com'),
+  iconProvider('2gis', '2GIS', 'https://2gis.com'),
+  iconProvider('cabify', 'Cabify', 'https://cabify.com'),
+  iconProvider('baidu', 'Baidu Maps', 'https://map.baidu.com'),
+  iconProvider('gaode', 'Gaode Maps', 'https://www.amap.com'),
+  iconProvider('tesla', 'Tesla', 'https://www.tesla.com'),
+  iconProvider('apple_maps', 'Apple Maps', 'https://www.apple.com/maps/'),
+  iconProvider('tomtom', 'TomTom', 'https://www.tomtom.com'),
+  iconProvider('transit_app', 'Transit App', 'https://transitapp.com'),
+  iconProvider('garmin_navigon', 'Garmin Navigon', 'https://www.garmin.com'),
+  iconProvider('99taxi', '99 Taxi', 'https://99app.com'),
 ];
+
+function iconProvider(app: string, name: string, url: string): IconProvider {
+  return {
+    app,
+    name,
+    url,
+    iconUrl: `https://favicone.com/${new URL(url).hostname}?s=128`,
+  };
+}
 
 interface StoredIconMetadata {
   app: string;
@@ -58,7 +68,7 @@ interface CachedWebIcon {
 
 const objectUrls = new Map<string, string>();
 
-export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlugin {
+export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlugin, LaunchNavigatorPluginIcons {
   /**
    * Navigate to a location using latitude and longitude
    * Opens the location in the default map application or Google Maps web
@@ -204,7 +214,9 @@ export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlug
     }
 
     try {
-      const sourceUrl = await discoverIconUrl(provider);
+      const sourceUrl = provider.iconUrl
+        ? absolutizeUrl(provider.iconUrl, provider.url)
+        : await discoverIconUrl(provider);
       const response = await fetch(sourceUrl);
       if (!response.ok) {
         throw new Error(`Icon request failed with status ${response.status}`);
@@ -263,11 +275,7 @@ function resolveIconProviders(options: GetAppIconsOptions): IconProvider[] {
     return options.apps.map((app) => builtIns.get(String(app)) || { app: String(app) });
   }
 
-  if (customProviders.length > 0) {
-    return customProviders.map((provider) => builtIns.get(String(provider.app)) || provider);
-  }
-
-  return [builtIns.get('google_maps') as IconProvider];
+  return Array.from(builtIns.values());
 }
 
 function normalizeMaxAge(maxAgeMs: number | undefined): number {
@@ -278,10 +286,6 @@ function normalizeMaxAge(maxAgeMs: number | undefined): number {
 }
 
 async function discoverIconUrl(provider: IconProvider): Promise<string> {
-  if (provider.iconUrl) {
-    return absolutizeUrl(provider.iconUrl, provider.url);
-  }
-
   if (!provider.url) {
     throw new Error('Provider url or iconUrl is required');
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -188,7 +188,7 @@ export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlug
       return { cleared };
     }
 
-    const storedApps = getStoredAppIds();
+    const storedApps = await getStoredAppIds(cache);
     for (const app of storedApps) {
       cleared += (await deleteCachedIcon(app, cache)) ? 1 : 0;
     }
@@ -388,19 +388,52 @@ function writeMetadata(metadata: StoredIconMetadata): void {
   }
 }
 
-function getStoredAppIds(): string[] {
-  const apps: string[] = [];
+async function getStoredAppIds(cache: Cache | undefined): Promise<string[]> {
+  const apps = new Set<string>();
   try {
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
       if (key?.startsWith(ICON_METADATA_PREFIX)) {
-        apps.push(key.slice(ICON_METADATA_PREFIX.length));
+        apps.add(key.slice(ICON_METADATA_PREFIX.length));
       }
     }
   } catch (error) {
     console.warn('Unable to read provider icon metadata', error);
   }
-  return apps;
+
+  const cachesToRead = new Map<string, Cache>();
+  if (cache) {
+    cachesToRead.set(ICON_CACHE_NAME, cache);
+  }
+
+  try {
+    if ('caches' in window) {
+      const cacheNames = await caches.keys();
+      for (const cacheName of cacheNames) {
+        if (cacheName === ICON_CACHE_NAME && !cachesToRead.has(cacheName)) {
+          cachesToRead.set(cacheName, await caches.open(cacheName));
+        }
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to enumerate provider icon caches', error);
+  }
+
+  try {
+    for (const iconCache of cachesToRead.values()) {
+      const requests = await iconCache.keys();
+      for (const request of requests) {
+        const app = appFromCacheRequest(request);
+        if (app) {
+          apps.add(app);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to read provider icon cache entries', error);
+  }
+
+  return Array.from(apps);
 }
 
 async function deleteCachedIcon(app: string, cache: Cache | undefined): Promise<boolean> {
@@ -427,6 +460,21 @@ async function deleteCachedIcon(app: string, cache: Cache | undefined): Promise<
 
 function metadataKey(app: string): string {
   return `${ICON_METADATA_PREFIX}${app}`;
+}
+
+function appFromCacheRequest(request: Request): string | undefined {
+  try {
+    const url = new URL(request.url);
+    const prefix = '/launch-navigator-icons/';
+    if (url.origin !== 'https://capgo.local' || !url.pathname.startsWith(prefix)) {
+      return undefined;
+    }
+
+    const app = decodeURIComponent(url.pathname.slice(prefix.length));
+    return app || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function setObjectUrl(app: string, url: string): void {

--- a/src/web.ts
+++ b/src/web.ts
@@ -236,10 +236,14 @@ export class LaunchNavigatorWeb extends WebPlugin implements LaunchNavigatorPlug
       setObjectUrl(app, localUrl);
 
       if (cache) {
-        await cache.put(
-          cacheRequest(app),
-          new Response(blob, { headers: mimeType ? { 'content-type': mimeType } : undefined }),
-        );
+        try {
+          await cache.put(
+            cacheRequest(app),
+            new Response(blob, { headers: mimeType ? { 'content-type': mimeType } : undefined }),
+          );
+        } catch (error) {
+          console.warn('Unable to persist provider icon in Cache Storage', error);
+        }
       }
       writeMetadata(metadata);
 
@@ -355,7 +359,12 @@ async function getCache(): Promise<Cache | undefined> {
   if (!('caches' in window)) {
     return undefined;
   }
-  return caches.open(ICON_CACHE_NAME);
+  try {
+    return await caches.open(ICON_CACHE_NAME);
+  } catch (error) {
+    console.warn('Unable to open provider icon cache', error);
+    return undefined;
+  }
 }
 
 function cacheRequest(app: string): Request {
@@ -372,29 +381,47 @@ function readMetadata(app: string): StoredIconMetadata | undefined {
 }
 
 function writeMetadata(metadata: StoredIconMetadata): void {
-  localStorage.setItem(metadataKey(metadata.app), JSON.stringify(metadata));
+  try {
+    localStorage.setItem(metadataKey(metadata.app), JSON.stringify(metadata));
+  } catch (error) {
+    console.warn('Unable to persist provider icon metadata', error);
+  }
 }
 
 function getStoredAppIds(): string[] {
   const apps: string[] = [];
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i);
-    if (key?.startsWith(ICON_METADATA_PREFIX)) {
-      apps.push(key.slice(ICON_METADATA_PREFIX.length));
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(ICON_METADATA_PREFIX)) {
+        apps.push(key.slice(ICON_METADATA_PREFIX.length));
+      }
     }
+  } catch (error) {
+    console.warn('Unable to read provider icon metadata', error);
   }
   return apps;
 }
 
 async function deleteCachedIcon(app: string, cache: Cache | undefined): Promise<boolean> {
-  const hadMetadata = localStorage.getItem(metadataKey(app)) !== null;
-  localStorage.removeItem(metadataKey(app));
+  let hadMetadata = false;
+  try {
+    hadMetadata = localStorage.getItem(metadataKey(app)) !== null;
+    localStorage.removeItem(metadataKey(app));
+  } catch (error) {
+    console.warn('Unable to clear provider icon metadata', error);
+  }
   const objectUrl = objectUrls.get(app);
   if (objectUrl) {
     URL.revokeObjectURL(objectUrl);
     objectUrls.delete(app);
   }
-  const deletedFromCache = (await cache?.delete(cacheRequest(app))) || false;
+  let deletedFromCache = false;
+  try {
+    deletedFromCache = (await cache?.delete(cacheRequest(app))) || false;
+  } catch (error) {
+    console.warn('Unable to clear provider icon cache entry', error);
+  }
   return hadMetadata || deletedFromCache;
 }
 


### PR DESCRIPTION
## What
- Add Guru Maps, Organic Maps, Yandex Maps, 2GIS, and Tesla to supported iOS navigation apps.
- Add TomTom GO, Guru Maps, Organic Maps, Yandex Maps, Mapy.com, 2GIS, and Tesla to supported Android navigation apps.
- Add URL scheme/package visibility docs and generated enum docs for the expanded app list.
- Fix packed example verification so existing platforms are synced instead of re-added, and align the example app splash screen plugin with Capacitor 8.

## Why
- Fixes #20 where Guru Maps was missing from the available app list after migrating from phonegap-launch-navigator.
- Gives apps a built-in way to offer common alternate navigation providers and send destinations to Tesla through a Google Maps directions link.
- Keeps CI packed-example verification working against the checked-in example app.

## How
- Added TypeScript enum entries, native app metadata, Android package queries, iOS URL schemes, and app-specific deep links.
- Android shares a Google Maps directions URL directly to the Tesla app package.
- iOS presents the native share sheet for Tesla because iOS does not allow directly selecting another app share extension.
- Android availability now checks whether the provider intent can resolve before launching.

## Testing
- `bun run build`
- `bun run lint`
- `bun run verify:ios`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" bun run verify:android`
- `bash ./.github/scripts/verify-packed-example.sh ios`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" bash ./.github/scripts/verify-packed-example.sh android`
- `git diff --check`

## Not Tested
- Manual launching into every third-party navigation app on physical iOS/Android devices.
- Manual Tesla send-to-car flow with an authenticated Tesla account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for many more navigation apps (TomTom, Guru Maps, Organic Maps, Yandex Maps, Mapy, 2GIS, Tesla, and others)
  * New app icon APIs on all platforms: getAppIcons, refreshAppIcons, clearIconCache with caching and refresh behavior

* **Documentation**
  * README updated with new apps, iOS/Android setup notes, icon API examples, and Tesla-specific guidance

* **Chores**
  * Bumped Capacitor splash-screen dependency

* **Bug Fixes**
  * Added network permission and expanded Android package queries for navigation apps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-launch-navigator/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->