### PR TITLE
[codex] fix Tesla navigation share payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ console.log('Icon failures:', failures);
 
 - **Coordinates Only**: This plugin only accepts latitude/longitude coordinates for navigation. Address strings are not supported.
 - **Address Geocoding**: If you need to convert addresses to coordinates, use [@capgo/capacitor-nativegeocoder](https://github.com/Cap-go/capacitor-nativegeocoder).
-- **Tesla**: `app: 'tesla'` shares a Google Maps directions link to the Tesla app. Android targets the Tesla app directly; iOS opens the native share sheet because iOS does not allow selecting another app's share extension programmatically.
+- **Tesla**: `app: 'tesla'` shares a Google Maps position text to the Tesla app. Android targets the Tesla app directly; iOS opens the native share sheet because iOS does not allow selecting another app's share extension programmatically.
 
 ## Supported Navigation Apps
 

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
@@ -497,7 +497,7 @@ public class LaunchNavigator {
     }
 
     static String createGoogleMapsPositionUrl(double lat, double lon) {
-        return String.format(Locale.US, "https://maps.google.com/?q=%f,%f", lat, lon);
+        return String.format(Locale.US, "https://maps.google.com/?q=%.6f,%.6f", lat, lon);
     }
 
     private static String createTeslaShareLabel(String destinationName) {

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
@@ -206,7 +206,7 @@ public class LaunchNavigator {
             case "gaode":
                 return createGaodeIntent(lat, lon, startLat, startLon);
             case "tesla":
-                return createTeslaIntent(lat, lon, startLat, startLon, transportMode);
+                return createTeslaIntent(lat, lon, destinationName);
             default:
                 return null;
         }
@@ -484,40 +484,29 @@ public class LaunchNavigator {
         return intent;
     }
 
-    private Intent createTeslaIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
+    private Intent createTeslaIntent(double lat, double lon, String destinationName) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_TEXT, createGoogleMapsWebUrl(lat, lon, startLat, startLon, transportMode));
+        intent.putExtra(Intent.EXTRA_TEXT, createTeslaShareText(lat, lon, destinationName));
         intent.setPackage("com.teslamotors.tesla");
         return intent;
     }
 
-    private String createGoogleMapsWebUrl(double lat, double lon, Double startLat, Double startLon, String transportMode) {
-        String url = String.format(
-            Locale.US,
-            "https://www.google.com/maps/dir/?api=1&destination=%f,%f&travelmode=%s",
-            lat,
-            lon,
-            getGoogleMapsTravelMode(transportMode)
-        );
-        if (startLat != null && startLon != null) {
-            url += String.format(Locale.US, "&origin=%f,%f", startLat, startLon);
-        }
-        return url;
+    static String createTeslaShareText(double lat, double lon, String destinationName) {
+        return createTeslaShareLabel(destinationName) + "\n\n" + createGoogleMapsPositionUrl(lat, lon);
     }
 
-    private String getGoogleMapsTravelMode(String transportMode) {
-        switch (transportMode) {
-            case "walking":
-                return "walking";
-            case "bicycling":
-                return "bicycling";
-            case "transit":
-                return "transit";
-            case "driving":
-            default:
-                return "driving";
+    static String createGoogleMapsPositionUrl(double lat, double lon) {
+        return String.format(Locale.US, "https://maps.google.com/?q=%f,%f", lat, lon);
+    }
+
+    private static String createTeslaShareLabel(String destinationName) {
+        if (destinationName == null) {
+            return "Dropped pin";
         }
+
+        String normalizedName = destinationName.trim().replaceAll("[\\r\\n]+", " ");
+        return normalizedName.isEmpty() ? "Dropped pin" : normalizedName;
     }
 
     public boolean isAppAvailable(String app) {

--- a/android/src/test/java/app/capgo/plugin/launch_navigator/LaunchNavigatorTest.java
+++ b/android/src/test/java/app/capgo/plugin/launch_navigator/LaunchNavigatorTest.java
@@ -1,0 +1,22 @@
+package app.capgo.plugin.launch_navigator;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LaunchNavigatorTest {
+
+    @Test
+    public void createTeslaShareTextUsesGoogleMapsPosition() {
+        String shareText = LaunchNavigator.createTeslaShareText(47.620500, -122.349300, "Space Needle");
+
+        assertEquals("Space Needle\n\nhttps://maps.google.com/?q=47.620500,-122.349300", shareText);
+    }
+
+    @Test
+    public void createTeslaShareTextFallsBackToDroppedPinLabel() {
+        String shareText = LaunchNavigator.createTeslaShareText(47.620500, -122.349300, "  \n  ");
+
+        assertEquals("Dropped pin\n\nhttps://maps.google.com/?q=47.620500,-122.349300", shareText);
+    }
+}

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
@@ -171,8 +171,7 @@ struct NavigationAppInfo {
         case "tesla":
             shareToTesla(
                 destination: destination,
-                start: start,
-                transportMode: transportMode,
+                destinationName: destinationName,
                 viewController: viewController,
                 completion: completion
             )
@@ -493,8 +492,7 @@ struct NavigationAppInfo {
 
     private func shareToTesla(
         destination: CLLocationCoordinate2D,
-        start: CLLocationCoordinate2D?,
-        transportMode: String,
+        destinationName: String?,
         viewController: UIViewController?,
         completion: @escaping (Bool, String?) -> Void
     ) {
@@ -503,12 +501,10 @@ struct NavigationAppInfo {
             return
         }
 
-        guard let url = googleMapsWebURL(destination: destination, start: start, transportMode: transportMode) else {
-            completion(false, "Invalid Tesla share URL")
-            return
-        }
-
-        let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        let activityViewController = UIActivityViewController(
+            activityItems: [teslaShareText(destination: destination, destinationName: destinationName)],
+            applicationActivities: nil
+        )
         activityViewController.popoverPresentationController?.sourceView = viewController.view
         activityViewController.completionWithItemsHandler = { _, completed, _, error in
             if let error = error {
@@ -523,31 +519,29 @@ struct NavigationAppInfo {
         viewController.present(activityViewController, animated: true)
     }
 
-    private func googleMapsWebURL(
-        destination: CLLocationCoordinate2D,
-        start: CLLocationCoordinate2D?,
-        transportMode: String
-    ) -> URL? {
-        var urlString = "https://www.google.com/maps/dir/?api=1&destination=\(destination.latitude),\(destination.longitude)&travelmode=\(googleMapsTravelMode(transportMode))"
-
-        if let startCoord = start {
-            urlString += "&origin=\(startCoord.latitude),\(startCoord.longitude)"
-        }
-
-        return URL(string: urlString)
+    func teslaShareText(destination: CLLocationCoordinate2D, destinationName: String?) -> String {
+        "\(teslaShareLabel(destinationName))\n\n\(googleMapsPositionURLString(destination: destination))"
     }
 
-    private func googleMapsTravelMode(_ transportMode: String) -> String {
-        switch transportMode {
-        case "walking":
-            return "walking"
-        case "bicycling":
-            return "bicycling"
-        case "transit":
-            return "transit"
-        default:
-            return "driving"
+    func googleMapsPositionURLString(destination: CLLocationCoordinate2D) -> String {
+        let coordinates = String(
+            format: "%.6f,%.6f",
+            locale: Locale(identifier: "en_US_POSIX"),
+            destination.latitude,
+            destination.longitude
+        )
+        return "https://maps.google.com/?q=\(coordinates)"
+    }
+
+    private func teslaShareLabel(_ destinationName: String?) -> String {
+        guard let destinationName = destinationName else {
+            return "Dropped pin"
         }
+
+        let normalizedName = destinationName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "[\\r\\n]+", with: " ", options: .regularExpression)
+        return normalizedName.isEmpty ? "Dropped pin" : normalizedName
     }
 
     private func encoded(_ value: String) -> String {

--- a/ios/Tests/LaunchNavigatorPluginTests/LaunchNavigatorPluginTests.swift
+++ b/ios/Tests/LaunchNavigatorPluginTests/LaunchNavigatorPluginTests.swift
@@ -1,15 +1,25 @@
 import XCTest
+import MapKit
 @testable import LaunchNavigatorPlugin
 
 class LaunchNavigatorTests: XCTestCase {
-    func testEcho() {
-        // This is an example of a functional test case for a plugin.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-
+    func testTeslaShareTextUsesGoogleMapsPosition() {
         let implementation = LaunchNavigator()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
+        let destination = CLLocationCoordinate2D(latitude: 47.6205, longitude: -122.3493)
 
-        XCTAssertEqual(value, result)
+        XCTAssertEqual(
+            "Space Needle\n\nhttps://maps.google.com/?q=47.620500,-122.349300",
+            implementation.teslaShareText(destination: destination, destinationName: "Space Needle")
+        )
+    }
+
+    func testTeslaShareTextFallsBackToDroppedPinLabel() {
+        let implementation = LaunchNavigator()
+        let destination = CLLocationCoordinate2D(latitude: 47.6205, longitude: -122.3493)
+
+        XCTAssertEqual(
+            "Dropped pin\n\nhttps://maps.google.com/?q=47.620500,-122.349300",
+            implementation.teslaShareText(destination: destination, destinationName: "  \n  ")
+        )
     }
 }


### PR DESCRIPTION
## What
- Change Tesla navigation sharing to send a Google Maps position text payload instead of a directions URL.
- Use the same Tesla share text on Android and iOS.
- Add Android and iOS tests for the generated Tesla share text.
- Update the Tesla note in the README.

## Why
- Fixes #22.
- Tesla expects destinations through the device share flow. The Tesla share command consumes shared text such as an address/name plus a Google Maps location link, while the previous directions URL could fail in the Tesla app.

## How
- Android now sends `Intent.ACTION_SEND` with `Intent.EXTRA_TEXT` formatted as `name\n\nhttps://maps.google.com/?q=lat,lng` and targets `com.teslamotors.tesla`.
- iOS now shares the same text through the native share sheet.
- Empty destination names fall back to `Dropped pin`.

## Testing
- `bun run build`
- `bun run lint` (passes with existing SwiftLint warnings)
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" bun run verify:android`
- `bun run verify:ios`
- `git diff --check`

## Not Tested
- Manual Tesla send-to-car flow with an authenticated Tesla account and vehicle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Tesla integration documentation to reflect new destination sharing behavior.

* **Tests**
  * Added test coverage for Tesla sharing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-launch-navigator/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->