### PR TITLE
[codex] fix phonegap navigation app parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add URL schemes to your `Info.plist` to detect installed navigation apps:
     <string>baidumap</string>
     <string>iosamap</string>
     <string>tesla</string>
-    <string>99app</string>
+    <string>taxis99</string>
 </array>
 ```
 
@@ -96,8 +96,14 @@ The following navigation apps are declared in the plugin's manifest:
     <package android:name="ru.dublgis.dgismobile" />
     <package android:name="com.cabify.rider" />
     <package android:name="com.baidu.BaiduMap" />
+    <package android:name="com.taxis99" />
     <package android:name="com.autonavi.minimap" />
     <package android:name="com.teslamotors.tesla" />
+
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <data android:scheme="geo" />
+    </intent>
 </queries>
 ```
 
@@ -165,6 +171,9 @@ console.log('Icon failures:', failures);
 - **Coordinates Only**: This plugin only accepts latitude/longitude coordinates for navigation. Address strings are not supported.
 - **Address Geocoding**: If you need to convert addresses to coordinates, use [@capgo/capacitor-nativegeocoder](https://github.com/Cap-go/capacitor-nativegeocoder).
 - **Tesla**: `app: 'tesla'` shares a Google Maps position text to the Tesla app. Android targets the Tesla app directly; iOS opens the native share sheet because iOS does not allow selecting another app's share extension programmatically.
+- **PhoneGap app identifiers**: App IDs now match `phonegap-launch-navigator` for Navigon, HERE Maps, MAPS.ME, and 99 Taxi. Legacy IDs (`garmin_navigon`, `here`, `mapsme`, `99taxi`) are still accepted.
+- **Android geo apps**: `app: 'geo'` opens the native Android chooser for any installed app that handles the `geo:` URI scheme. `getAvailableApps()` also returns discovered `geo:` apps by package name, so apps like Locus Map, Komoot, and OsmAnd can be listed when installed.
+- **99 Taxi**: `app: 'taxis_99'` follows the PhoneGap app identifier. A start coordinate is required.
 
 ## Supported Navigation Apps
 
@@ -194,6 +203,7 @@ console.log('Icon failures:', failures);
 - 99 Taxi
 
 ### Android
+- Geo intent chooser
 - Google Maps
 - Waze
 - Citymapper
@@ -212,8 +222,10 @@ console.log('Icon failures:', failures);
 - 2GIS
 - Cabify
 - Baidu Maps
+- 99 Taxi
 - Gaode Maps
 - Tesla
+- Any installed app that supports the Android `geo:` URI scheme
 
 ## API
 
@@ -503,47 +515,50 @@ Construct a type with a set of properties K of type T
 
 #### IOSNavigationApp
 
-| Members                | Value                         |
-| ---------------------- | ----------------------------- |
-| **`APPLE_MAPS`**       | <code>'apple_maps'</code>     |
-| **`GOOGLE_MAPS`**      | <code>'google_maps'</code>    |
-| **`WAZE`**             | <code>'waze'</code>           |
-| **`CITYMAPPER`**       | <code>'citymapper'</code>     |
-| **`GARMIN_NAVIGON`**   | <code>'garmin_navigon'</code> |
-| **`TRANSIT_APP`**      | <code>'transit_app'</code>    |
-| **`YANDEX_NAVIGATOR`** | <code>'yandex'</code>         |
-| **`UBER`**             | <code>'uber'</code>           |
-| **`TOMTOM`**           | <code>'tomtom'</code>         |
-| **`SYGIC`**            | <code>'sygic'</code>          |
-| **`HERE_MAPS`**        | <code>'here'</code>           |
-| **`MOOVIT`**           | <code>'moovit'</code>         |
-| **`LYFT`**             | <code>'lyft'</code>           |
-| **`MAPS_ME`**          | <code>'mapsme'</code>         |
-| **`GURU_MAPS`**        | <code>'guru_maps'</code>      |
-| **`ORGANIC_MAPS`**     | <code>'organic_maps'</code>   |
-| **`YANDEX_MAPS`**      | <code>'yandex_maps'</code>    |
-| **`TWO_GIS`**          | <code>'2gis'</code>           |
-| **`CABIFY`**           | <code>'cabify'</code>         |
-| **`BAIDU`**            | <code>'baidu'</code>          |
-| **`GAODE`**            | <code>'gaode'</code>          |
-| **`TESLA`**            | <code>'tesla'</code>          |
-| **`TAXI_99`**          | <code>'99taxi'</code>         |
+| Members                | Value                       |
+| ---------------------- | --------------------------- |
+| **`APPLE_MAPS`**       | <code>'apple_maps'</code>   |
+| **`GOOGLE_MAPS`**      | <code>'google_maps'</code>  |
+| **`WAZE`**             | <code>'waze'</code>         |
+| **`CITYMAPPER`**       | <code>'citymapper'</code>   |
+| **`NAVIGON`**          | <code>'navigon'</code>      |
+| **`GARMIN_NAVIGON`**   | <code>'navigon'</code>      |
+| **`TRANSIT_APP`**      | <code>'transit_app'</code>  |
+| **`YANDEX_NAVIGATOR`** | <code>'yandex'</code>       |
+| **`UBER`**             | <code>'uber'</code>         |
+| **`TOMTOM`**           | <code>'tomtom'</code>       |
+| **`SYGIC`**            | <code>'sygic'</code>        |
+| **`HERE_MAPS`**        | <code>'here_maps'</code>    |
+| **`MOOVIT`**           | <code>'moovit'</code>       |
+| **`LYFT`**             | <code>'lyft'</code>         |
+| **`MAPS_ME`**          | <code>'maps_me'</code>      |
+| **`GURU_MAPS`**        | <code>'guru_maps'</code>    |
+| **`ORGANIC_MAPS`**     | <code>'organic_maps'</code> |
+| **`YANDEX_MAPS`**      | <code>'yandex_maps'</code>  |
+| **`TWO_GIS`**          | <code>'2gis'</code>         |
+| **`CABIFY`**           | <code>'cabify'</code>       |
+| **`BAIDU`**            | <code>'baidu'</code>        |
+| **`GAODE`**            | <code>'gaode'</code>        |
+| **`TESLA`**            | <code>'tesla'</code>        |
+| **`TAXIS_99`**         | <code>'taxis_99'</code>     |
+| **`TAXI_99`**          | <code>'taxis_99'</code>     |
 
 
 #### AndroidNavigationApp
 
 | Members            | Value                       |
 | ------------------ | --------------------------- |
+| **`GEO`**          | <code>'geo'</code>          |
 | **`GOOGLE_MAPS`**  | <code>'google_maps'</code>  |
 | **`WAZE`**         | <code>'waze'</code>         |
 | **`CITYMAPPER`**   | <code>'citymapper'</code>   |
 | **`UBER`**         | <code>'uber'</code>         |
 | **`YANDEX`**       | <code>'yandex'</code>       |
 | **`SYGIC`**        | <code>'sygic'</code>        |
-| **`HERE_MAPS`**    | <code>'here'</code>         |
+| **`HERE_MAPS`**    | <code>'here_maps'</code>    |
 | **`MOOVIT`**       | <code>'moovit'</code>       |
 | **`LYFT`**         | <code>'lyft'</code>         |
-| **`MAPS_ME`**      | <code>'mapsme'</code>       |
+| **`MAPS_ME`**      | <code>'maps_me'</code>      |
 | **`TOMTOM`**       | <code>'tomtom'</code>       |
 | **`GURU_MAPS`**    | <code>'guru_maps'</code>    |
 | **`ORGANIC_MAPS`** | <code>'organic_maps'</code> |
@@ -553,6 +568,8 @@ Construct a type with a set of properties K of type T
 | **`CABIFY`**       | <code>'cabify'</code>       |
 | **`BAIDU`**        | <code>'baidu'</code>        |
 | **`GAODE`**        | <code>'gaode'</code>        |
+| **`TAXIS_99`**     | <code>'taxis_99'</code>     |
+| **`TAXI_99`**      | <code>'taxis_99'</code>     |
 | **`TESLA`**        | <code>'tesla'</code>        |
 
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -21,7 +21,13 @@
         <package android:name="ru.dublgis.dgismobile" />
         <package android:name="com.cabify.rider" />
         <package android:name="com.baidu.BaiduMap" />
+        <package android:name="com.taxis99" />
         <package android:name="com.autonavi.minimap" />
         <package android:name="com.teslamotors.tesla" />
+
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="geo" />
+        </intent>
     </queries>
 </manifest>

--- a/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
+++ b/android/src/main/java/app/capgo/plugin/launch_navigator/LaunchNavigator.java
@@ -3,6 +3,7 @@ package app.capgo.plugin.launch_navigator;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import com.getcapacitor.Bridge;
 import com.getcapacitor.FileUtils;
@@ -20,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,12 +44,25 @@ public class LaunchNavigator {
         Pattern.CASE_INSENSITIVE
     );
     private static final Pattern HREF_PATTERN = Pattern.compile("\\shref=[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+    private static final String APP_GEO = "geo";
+    private static final String APP_HERE_MAPS = "here_maps";
+    private static final String APP_MAPS_ME = "maps_me";
+    private static final String APP_TAXIS_99 = "taxis_99";
+    private static final Map<String, String> APP_ALIASES = createAppAliases();
 
     private final Context context;
     private final Bridge bridge;
     private final Map<String, Object> iconCacheLocks = new ConcurrentHashMap<>();
     private final ReentrantReadWriteLock iconCacheDirectoryLock = new ReentrantReadWriteLock();
     private Map<String, AppInfo> navigationApps;
+
+    private static Map<String, String> createAppAliases() {
+        Map<String, String> aliases = new LinkedHashMap<>();
+        aliases.put("here", APP_HERE_MAPS);
+        aliases.put("mapsme", APP_MAPS_ME);
+        aliases.put("99taxi", APP_TAXIS_99);
+        return aliases;
+    }
 
     private static class AppInfo {
 
@@ -109,25 +124,27 @@ public class LaunchNavigator {
 
     private void initializeApps() {
         navigationApps = new LinkedHashMap<>();
+        navigationApps.put(APP_GEO, new AppInfo("[Geo intent chooser]", null));
         navigationApps.put("google_maps", new AppInfo("Google Maps", "https://www.google.com/maps", "com.google.android.apps.maps"));
         navigationApps.put("waze", new AppInfo("Waze", "https://www.waze.com", "com.waze"));
         navigationApps.put("citymapper", new AppInfo("Citymapper", "https://citymapper.com", "com.citymapper.app.release"));
         navigationApps.put("uber", new AppInfo("Uber", "https://www.uber.com", "com.ubercab"));
         navigationApps.put("yandex", new AppInfo("Yandex Navigator", "https://yandex.com/maps", "ru.yandex.yandexnavi"));
         navigationApps.put("sygic", new AppInfo("Sygic", "https://www.sygic.com/gps-navigation", "com.sygic.aura"));
-        navigationApps.put("here", new AppInfo("HERE Maps", "https://wego.here.com", "com.here.app.maps"));
+        navigationApps.put(APP_HERE_MAPS, new AppInfo("HERE Maps", "https://wego.here.com", "com.here.app.maps"));
         navigationApps.put("moovit", new AppInfo("Moovit", "https://moovitapp.com", "com.tranzmate"));
         navigationApps.put("lyft", new AppInfo("Lyft", "https://www.lyft.com", "me.lyft.android"));
-        navigationApps.put("mapsme", new AppInfo("MAPS.ME", "https://maps.me", "com.mapswithme.maps.pro"));
+        navigationApps.put(APP_MAPS_ME, new AppInfo("MAPS.ME", "https://maps.me", "com.mapswithme.maps.pro"));
+        navigationApps.put("cabify", new AppInfo("Cabify", "https://cabify.com", "com.cabify.rider"));
+        navigationApps.put("baidu", new AppInfo("Baidu Maps", "https://map.baidu.com", "com.baidu.BaiduMap"));
+        navigationApps.put(APP_TAXIS_99, new AppInfo("99 Taxi", "https://99app.com", "com.taxis99"));
+        navigationApps.put("gaode", new AppInfo("Gaode Maps", "https://www.amap.com", "com.autonavi.minimap"));
         navigationApps.put("tomtom", new AppInfo("TomTom GO", "https://www.tomtom.com", "com.tomtom.gplay.navapp"));
         navigationApps.put("guru_maps", new AppInfo("Guru Maps", "https://gurumaps.app", "com.bodunov.galileo", "com.bodunov.GalileoPro"));
         navigationApps.put("organic_maps", new AppInfo("Organic Maps", "https://organicmaps.app", "app.organicmaps"));
         navigationApps.put("yandex_maps", new AppInfo("Yandex Maps", "https://yandex.com/maps", "ru.yandex.yandexmaps"));
         navigationApps.put("mapy", new AppInfo("Mapy.com", "https://mapy.com", "cz.seznam.mapy"));
         navigationApps.put("2gis", new AppInfo("2GIS", "https://2gis.com", "ru.dublgis.dgismobile"));
-        navigationApps.put("cabify", new AppInfo("Cabify", "https://cabify.com", "com.cabify.rider"));
-        navigationApps.put("baidu", new AppInfo("Baidu Maps", "https://map.baidu.com", "com.baidu.BaiduMap"));
-        navigationApps.put("gaode", new AppInfo("Gaode Maps", "https://www.amap.com", "com.autonavi.minimap"));
         navigationApps.put("tesla", new AppInfo("Tesla", "https://www.tesla.com", "com.teslamotors.tesla"));
     }
 
@@ -142,9 +159,13 @@ public class LaunchNavigator {
         String transportMode
     ) {
         try {
-            Intent intent = createNavigationIntent(app, lat, lon, startLat, startLon, destinationName, transportMode);
+            String canonicalApp = canonicalApp(app);
+            Intent intent = createNavigationIntent(canonicalApp, lat, lon, startLat, startLon, startName, destinationName, transportMode);
 
             if (intent != null && canResolveIntent(intent)) {
+                if (APP_GEO.equals(canonicalApp)) {
+                    intent = Intent.createChooser(intent, "Select app for navigation");
+                }
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 context.startActivity(intent);
                 return true;
@@ -163,10 +184,13 @@ public class LaunchNavigator {
         double lon,
         Double startLat,
         Double startLon,
+        String startName,
         String destinationName,
         String transportMode
     ) {
         switch (app) {
+            case APP_GEO:
+                return createGeoIntent(lat, lon, destinationName, null);
             case "google_maps":
                 return createGoogleMapsIntent(lat, lon, startLat, startLon, transportMode);
             case "waze":
@@ -179,13 +203,13 @@ public class LaunchNavigator {
                 return createYandexIntent(lat, lon, startLat, startLon);
             case "sygic":
                 return createSygicIntent(lat, lon);
-            case "here":
+            case APP_HERE_MAPS:
                 return createHereIntent(lat, lon, startLat, startLon);
             case "moovit":
                 return createMoovitIntent(lat, lon, startLat, startLon);
             case "lyft":
                 return createLyftIntent(lat, lon);
-            case "mapsme":
+            case APP_MAPS_ME:
                 return createMapsMeIntent(lat, lon);
             case "tomtom":
                 return createTomTomIntent(lat, lon);
@@ -205,11 +229,37 @@ public class LaunchNavigator {
                 return createBaiduIntent(lat, lon, startLat, startLon);
             case "gaode":
                 return createGaodeIntent(lat, lon, startLat, startLon);
+            case APP_TAXIS_99:
+                return create99TaxiIntent(lat, lon, startLat, startLon, destinationName, startName);
             case "tesla":
                 return createTeslaIntent(lat, lon, destinationName);
             default:
-                return null;
+                String geoPackageName = getAvailableGeoPackage(app);
+                return geoPackageName == null ? null : createGeoIntent(lat, lon, destinationName, geoPackageName);
         }
+    }
+
+    private String canonicalApp(String app) {
+        if (app == null) {
+            return null;
+        }
+        String alias = APP_ALIASES.get(app);
+        return alias == null ? app : alias;
+    }
+
+    private Intent createGeoIntent(double lat, double lon, String destinationName, String packageName) {
+        String destination = String.format(Locale.US, "%f,%f", lat, lon);
+        String query = destination;
+        if (destinationName != null && !destinationName.trim().isEmpty()) {
+            query += "(" + destinationName.trim() + ")";
+        }
+
+        String uri = String.format(Locale.US, "geo:%f,%f?q=%s", lat, lon, Uri.encode(query, ",()"));
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        if (packageName != null) {
+            intent.setPackage(packageName);
+        }
+        return intent;
     }
 
     private Intent createGoogleMapsIntent(double lat, double lon, Double startLat, Double startLon, String transportMode) {
@@ -484,6 +534,34 @@ public class LaunchNavigator {
         return intent;
     }
 
+    private Intent create99TaxiIntent(double lat, double lon, Double startLat, Double startLon, String destinationName, String startName) {
+        if (startLat == null || startLon == null) {
+            return null;
+        }
+
+        String uri = String.format(
+            Locale.US,
+            "taxis99://call?dropoff_latitude=%f&dropoff_longitude=%f&dropoff_title=%s&pickup_latitude=%f&pickup_longitude=%f&pickup_title=%s&deep_link_product_id=316&client_id=MAP_123",
+            lat,
+            lon,
+            Uri.encode(normalizedLabel(destinationName, "Dropoff")),
+            startLat,
+            startLon,
+            Uri.encode(normalizedLabel(startName, "Pickup"))
+        );
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(uri));
+        intent.setPackage("com.taxis99");
+        return intent;
+    }
+
+    private String normalizedLabel(String label, String fallback) {
+        if (label == null) {
+            return fallback;
+        }
+        String normalized = label.trim();
+        return normalized.isEmpty() ? fallback : normalized;
+    }
+
     private Intent createTeslaIntent(double lat, double lon, String destinationName) {
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
@@ -510,7 +588,7 @@ public class LaunchNavigator {
     }
 
     public boolean isAppAvailable(String app) {
-        Intent intent = createNavigationIntent(app, 0, 0, null, null, null, "driving");
+        Intent intent = createNavigationIntent(canonicalApp(app), 0, 0, null, null, null, null, "driving");
         return intent != null && canResolveIntent(intent);
     }
 
@@ -519,8 +597,54 @@ public class LaunchNavigator {
         return intent.resolveActivity(pm) != null || !pm.queryIntentActivities(intent, 0).isEmpty();
     }
 
+    private String getAvailableGeoPackage(String app) {
+        if (app == null || app.isEmpty()) {
+            return null;
+        }
+        return discoverGeoApps().containsKey(app) ? app : null;
+    }
+
+    private Map<String, String> discoverGeoApps() {
+        Map<String, String> apps = new LinkedHashMap<>();
+        PackageManager pm = context.getPackageManager();
+        List<ResolveInfo> resolveInfoList = pm.queryIntentActivities(createGeoIntent(0, 0, null, null), 0);
+
+        for (ResolveInfo resolveInfo : resolveInfoList) {
+            if (resolveInfo.activityInfo == null || resolveInfo.activityInfo.packageName == null) {
+                continue;
+            }
+
+            String packageName = resolveInfo.activityInfo.packageName;
+            if (!isKnownAppPackage(packageName)) {
+                apps.put(packageName, getAppLabel(packageName));
+            }
+        }
+
+        return apps;
+    }
+
+    private boolean isKnownAppPackage(String packageName) {
+        for (AppInfo appInfo : navigationApps.values()) {
+            for (String knownPackageName : appInfo.packageNames) {
+                if (knownPackageName.equals(packageName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private String getAppLabel(String packageName) {
+        PackageManager pm = context.getPackageManager();
+        try {
+            return pm.getApplicationLabel(pm.getApplicationInfo(packageName, 0)).toString();
+        } catch (PackageManager.NameNotFoundException e) {
+            return packageName;
+        }
+    }
+
     private String getFirstInstalledPackage(String app) {
-        AppInfo appInfo = navigationApps.get(app);
+        AppInfo appInfo = navigationApps.get(canonicalApp(app));
         if (appInfo == null) {
             return null;
         }
@@ -943,7 +1067,9 @@ public class LaunchNavigator {
         Map<String, IconProvider> providers = new LinkedHashMap<>();
 
         for (Map.Entry<String, AppInfo> entry : navigationApps.entrySet()) {
-            providers.put(entry.getKey(), new IconProvider(entry.getKey(), entry.getValue().name, entry.getValue().url, null));
+            if (entry.getValue().url != null) {
+                providers.put(entry.getKey(), new IconProvider(entry.getKey(), entry.getValue().name, entry.getValue().url, null));
+            }
         }
 
         JSONArray customProviders = options.optJSONArray("providers");
@@ -954,7 +1080,7 @@ public class LaunchNavigator {
                     continue;
                 }
 
-                String app = providerObject.optString("app", "");
+                String app = canonicalApp(providerObject.optString("app", ""));
                 if (app.isEmpty()) {
                     continue;
                 }
@@ -971,7 +1097,7 @@ public class LaunchNavigator {
         if (apps != null && apps.length() > 0) {
             IconProvider[] selected = new IconProvider[apps.length()];
             for (int i = 0; i < apps.length(); i++) {
-                String app = apps.optString(i, "");
+                String app = canonicalApp(apps.optString(i, ""));
                 IconProvider provider = providers.get(app);
                 selected[i] = provider == null ? new IconProvider(app, null, null, null) : provider;
             }
@@ -1069,6 +1195,14 @@ public class LaunchNavigator {
             apps.put(appObject);
         }
 
+        for (Map.Entry<String, String> entry : discoverGeoApps().entrySet()) {
+            JSObject appObject = new JSObject();
+            appObject.put("app", entry.getKey());
+            appObject.put("name", entry.getValue());
+            appObject.put("available", true);
+            apps.put(appObject);
+        }
+
         return apps;
     }
 
@@ -1077,6 +1211,10 @@ public class LaunchNavigator {
 
         for (String appKey : navigationApps.keySet()) {
             apps.put(appKey);
+        }
+
+        for (String packageName : discoverGeoApps().keySet()) {
+            apps.put(packageName);
         }
 
         return apps;

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigator.swift
@@ -18,16 +18,16 @@ struct NavigationAppInfo {
         "google_maps": NavigationAppInfo(name: "Google Maps", urlScheme: "comgooglemaps://", url: "https://www.google.com/maps"),
         "waze": NavigationAppInfo(name: "Waze", urlScheme: "waze://", url: "https://www.waze.com"),
         "citymapper": NavigationAppInfo(name: "Citymapper", urlScheme: "citymapper://", url: "https://citymapper.com"),
-        "garmin_navigon": NavigationAppInfo(name: "Garmin Navigon", urlScheme: "navigon://", url: "https://www.garmin.com"),
+        "navigon": NavigationAppInfo(name: "Garmin Navigon", urlScheme: "navigon://", url: "https://www.garmin.com"),
         "transit_app": NavigationAppInfo(name: "Transit App", urlScheme: "transit://", url: "https://transitapp.com"),
         "yandex": NavigationAppInfo(name: "Yandex Navigator", urlScheme: "yandexnavi://", url: "https://yandex.com/maps"),
         "uber": NavigationAppInfo(name: "Uber", urlScheme: "uber://", url: "https://www.uber.com"),
         "tomtom": NavigationAppInfo(name: "TomTom", urlScheme: "tomtomgo://", url: "https://www.tomtom.com"),
         "sygic": NavigationAppInfo(name: "Sygic", urlScheme: "com.sygic.aura://", url: "https://www.sygic.com/gps-navigation"),
-        "here": NavigationAppInfo(name: "HERE Maps", urlScheme: "here-route://", url: "https://wego.here.com"),
+        "here_maps": NavigationAppInfo(name: "HERE Maps", urlScheme: "here-route://", url: "https://wego.here.com"),
         "moovit": NavigationAppInfo(name: "Moovit", urlScheme: "moovit://", url: "https://moovitapp.com"),
         "lyft": NavigationAppInfo(name: "Lyft", urlScheme: "lyft://", url: "https://www.lyft.com"),
-        "mapsme": NavigationAppInfo(name: "MAPS.ME", urlScheme: "mapsme://", url: "https://maps.me"),
+        "maps_me": NavigationAppInfo(name: "MAPS.ME", urlScheme: "mapsme://", url: "https://maps.me"),
         "guru_maps": NavigationAppInfo(name: "Guru Maps", urlScheme: "guru://", url: "https://gurumaps.app"),
         "organic_maps": NavigationAppInfo(name: "Organic Maps", urlScheme: "om://", url: "https://organicmaps.app"),
         "yandex_maps": NavigationAppInfo(name: "Yandex Maps", urlScheme: "yandexmaps://", url: "https://yandex.com/maps"),
@@ -36,7 +36,14 @@ struct NavigationAppInfo {
         "baidu": NavigationAppInfo(name: "Baidu Maps", urlScheme: "baidumap://", url: "https://map.baidu.com"),
         "gaode": NavigationAppInfo(name: "Gaode Maps", urlScheme: "iosamap://", url: "https://www.amap.com"),
         "tesla": NavigationAppInfo(name: "Tesla", urlScheme: "tesla://", url: "https://www.tesla.com"),
-        "99taxi": NavigationAppInfo(name: "99 Taxi", urlScheme: "99app://", url: "https://99app.com")
+        "taxis_99": NavigationAppInfo(name: "99 Taxi", urlScheme: "taxis99://", url: "https://99app.com")
+    ]
+
+    let appAliases: [String: String] = [
+        "garmin_navigon": "navigon",
+        "here": "here_maps",
+        "mapsme": "maps_me",
+        "99taxi": "taxis_99"
     ]
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length function_parameter_count
@@ -50,7 +57,7 @@ struct NavigationAppInfo {
         viewController: UIViewController? = nil,
         completion: @escaping (Bool, String?) -> Void
     ) {
-        switch app {
+        switch canonicalApp(app) {
         case "apple_maps":
             launchAppleMaps(
                 destination: destination,
@@ -74,6 +81,18 @@ struct NavigationAppInfo {
             )
         case "citymapper":
             launchCitymapper(
+                destination: destination,
+                start: start,
+                completion: completion
+            )
+        case "navigon":
+            launchNavigon(
+                destination: destination,
+                destinationName: destinationName,
+                completion: completion
+            )
+        case "transit_app":
+            launchTransitApp(
                 destination: destination,
                 start: start,
                 completion: completion
@@ -106,7 +125,7 @@ struct NavigationAppInfo {
                 destination: destination,
                 completion: completion
             )
-        case "here":
+        case "here_maps":
             launchHere(
                 destination: destination,
                 start: start,
@@ -117,7 +136,7 @@ struct NavigationAppInfo {
                 destination: destination,
                 completion: completion
             )
-        case "mapsme":
+        case "maps_me":
             launchMapsMe(
                 destination: destination,
                 completion: completion
@@ -166,6 +185,14 @@ struct NavigationAppInfo {
             launchGaode(
                 destination: destination,
                 start: start,
+                completion: completion
+            )
+        case "taxis_99":
+            launch99Taxi(
+                destination: destination,
+                start: start,
+                startName: startName,
+                destinationName: destinationName,
                 completion: completion
             )
         case "tesla":
@@ -260,6 +287,32 @@ struct NavigationAppInfo {
             urlString += "&startcoord=\(startCoord.latitude),\(startCoord.longitude)"
         }
 
+        openURL(urlString, completion: completion)
+    }
+
+    private func launchNavigon(
+        destination: CLLocationCoordinate2D,
+        destinationName: String?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        let name = destinationName.flatMap { $0.trimmedNonEmpty } ?? "Destination"
+        let urlString = "navigon://coordinate/\(encoded(name))/\(destination.longitude)/\(destination.latitude)"
+        openURL(urlString, completion: completion)
+    }
+
+    private func launchTransitApp(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        var params: [String] = []
+
+        if let startCoord = start {
+            params.append("from=\(startCoord.latitude),\(startCoord.longitude)")
+        }
+
+        params.append("to=\(destination.latitude),\(destination.longitude)")
+        let urlString = "transit://directions?\(params.joined(separator: "&"))"
         openURL(urlString, completion: completion)
     }
 
@@ -490,6 +543,25 @@ struct NavigationAppInfo {
         openURL(urlString, completion: completion)
     }
 
+    private func launch99Taxi(
+        destination: CLLocationCoordinate2D,
+        start: CLLocationCoordinate2D?,
+        startName: String?,
+        destinationName: String?,
+        completion: @escaping (Bool, String?) -> Void
+    ) {
+        guard let startCoord = start else {
+            completion(false, "Start location is required for 99 Taxi")
+            return
+        }
+
+        let pickupTitle = encoded(startName.flatMap { $0.trimmedNonEmpty } ?? "Pickup")
+        let dropoffTitle = encoded(destinationName.flatMap { $0.trimmedNonEmpty } ?? "Dropoff")
+        let urlString = "taxis99://call?pickup_latitude=\(startCoord.latitude)&pickup_longitude=\(startCoord.longitude)&pickup_title=\(pickupTitle)&dropoff_latitude=\(destination.latitude)&dropoff_longitude=\(destination.longitude)&dropoff_title=\(dropoffTitle)&deep_link_product_id=316&client_id=MAP_123"
+
+        openURL(urlString, completion: completion)
+    }
+
     private func shareToTesla(
         destination: CLLocationCoordinate2D,
         destinationName: String?,
@@ -569,8 +641,12 @@ struct NavigationAppInfo {
         }
     }
 
+    func canonicalApp(_ app: String) -> String {
+        appAliases[app] ?? app
+    }
+
     public func isAppAvailable(app: String) -> Bool {
-        guard let appInfo = navigationApps[app] else {
+        guard let appInfo = navigationApps[canonicalApp(app)] else {
             return false
         }
 
@@ -598,6 +674,13 @@ struct NavigationAppInfo {
 
     public func getSupportedApps() -> [String] {
         return Array(navigationApps.keys)
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 // swiftlint:enable type_body_length

--- a/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
+++ b/ios/Sources/LaunchNavigatorPlugin/LaunchNavigatorIcons.swift
@@ -368,10 +368,11 @@ extension LaunchNavigator {
 
         let customProviders = options["providers"] as? [[String: Any]] ?? []
         for providerObject in customProviders {
-            guard let app = providerObject["app"] as? String, !app.isEmpty else {
+            guard let appValue = providerObject["app"] as? String, !appValue.isEmpty else {
                 continue
             }
 
+            let app = canonicalApp(appValue)
             let existing = providers[app]
             providers[app] = IconProvider(
                 app: app,
@@ -383,7 +384,8 @@ extension LaunchNavigator {
 
         if let apps = options["apps"] as? [String], !apps.isEmpty {
             return apps.map { app in
-                providers[app] ?? IconProvider(app: app, name: nil, url: nil, iconUrl: nil)
+                let canonical = canonicalApp(app)
+                return providers[canonical] ?? IconProvider(app: canonical, name: nil, url: nil, iconUrl: nil)
             }
         }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,16 +6,17 @@ export enum IOSNavigationApp {
   GOOGLE_MAPS = 'google_maps',
   WAZE = 'waze',
   CITYMAPPER = 'citymapper',
-  GARMIN_NAVIGON = 'garmin_navigon',
+  NAVIGON = 'navigon',
+  GARMIN_NAVIGON = 'navigon',
   TRANSIT_APP = 'transit_app',
   YANDEX_NAVIGATOR = 'yandex',
   UBER = 'uber',
   TOMTOM = 'tomtom',
   SYGIC = 'sygic',
-  HERE_MAPS = 'here',
+  HERE_MAPS = 'here_maps',
   MOOVIT = 'moovit',
   LYFT = 'lyft',
-  MAPS_ME = 'mapsme',
+  MAPS_ME = 'maps_me',
   GURU_MAPS = 'guru_maps',
   ORGANIC_MAPS = 'organic_maps',
   YANDEX_MAPS = 'yandex_maps',
@@ -24,23 +25,25 @@ export enum IOSNavigationApp {
   BAIDU = 'baidu',
   GAODE = 'gaode',
   TESLA = 'tesla',
-  TAXI_99 = '99taxi',
+  TAXIS_99 = 'taxis_99',
+  TAXI_99 = 'taxis_99',
 }
 
 /**
  * Available navigation apps for Android
  */
 export enum AndroidNavigationApp {
+  GEO = 'geo',
   GOOGLE_MAPS = 'google_maps',
   WAZE = 'waze',
   CITYMAPPER = 'citymapper',
   UBER = 'uber',
   YANDEX = 'yandex',
   SYGIC = 'sygic',
-  HERE_MAPS = 'here',
+  HERE_MAPS = 'here_maps',
   MOOVIT = 'moovit',
   LYFT = 'lyft',
-  MAPS_ME = 'mapsme',
+  MAPS_ME = 'maps_me',
   TOMTOM = 'tomtom',
   GURU_MAPS = 'guru_maps',
   ORGANIC_MAPS = 'organic_maps',
@@ -50,6 +53,8 @@ export enum AndroidNavigationApp {
   CABIFY = 'cabify',
   BAIDU = 'baidu',
   GAODE = 'gaode',
+  TAXIS_99 = 'taxis_99',
+  TAXI_99 = 'taxis_99',
   TESLA = 'tesla',
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -16,6 +16,12 @@ import type {
 const DEFAULT_ICON_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const ICON_CACHE_NAME = 'capgo-launch-navigator-icons';
 const ICON_METADATA_PREFIX = 'capgo-launch-navigator-icon:';
+const APP_ALIASES: Record<string, string> = {
+  garmin_navigon: 'navigon',
+  here: 'here_maps',
+  mapsme: 'maps_me',
+  '99taxi': 'taxis_99',
+};
 
 const BUILT_IN_ICON_PROVIDERS: IconProvider[] = [
   iconProvider('google_maps', 'Google Maps', 'https://www.google.com/maps'),
@@ -24,10 +30,10 @@ const BUILT_IN_ICON_PROVIDERS: IconProvider[] = [
   iconProvider('uber', 'Uber', 'https://www.uber.com'),
   iconProvider('yandex', 'Yandex Navigator', 'https://yandex.com/maps'),
   iconProvider('sygic', 'Sygic', 'https://www.sygic.com/gps-navigation'),
-  iconProvider('here', 'HERE Maps', 'https://wego.here.com'),
+  iconProvider('here_maps', 'HERE Maps', 'https://wego.here.com'),
   iconProvider('moovit', 'Moovit', 'https://moovitapp.com'),
   iconProvider('lyft', 'Lyft', 'https://www.lyft.com'),
-  iconProvider('mapsme', 'MAPS.ME', 'https://maps.me'),
+  iconProvider('maps_me', 'MAPS.ME', 'https://maps.me'),
   iconProvider('guru_maps', 'Guru Maps', 'https://gurumaps.app'),
   iconProvider('organic_maps', 'Organic Maps', 'https://organicmaps.app'),
   iconProvider('yandex_maps', 'Yandex Maps', 'https://yandex.com/maps'),
@@ -40,8 +46,8 @@ const BUILT_IN_ICON_PROVIDERS: IconProvider[] = [
   iconProvider('apple_maps', 'Apple Maps', 'https://www.apple.com/maps/'),
   iconProvider('tomtom', 'TomTom', 'https://www.tomtom.com'),
   iconProvider('transit_app', 'Transit App', 'https://transitapp.com'),
-  iconProvider('garmin_navigon', 'Garmin Navigon', 'https://www.garmin.com'),
-  iconProvider('99taxi', '99 Taxi', 'https://99app.com'),
+  iconProvider('navigon', 'Garmin Navigon', 'https://www.garmin.com'),
+  iconProvider('taxis_99', '99 Taxi', 'https://99app.com'),
 ];
 
 function iconProvider(app: string, name: string, url: string): IconProvider {
@@ -271,15 +277,23 @@ function resolveIconProviders(options: GetAppIconsOptions): IconProvider[] {
   const customProviders = options.providers || [];
 
   for (const provider of customProviders) {
-    const app = String(provider.app);
+    const app = canonicalApp(provider.app);
     builtIns.set(app, { ...builtIns.get(app), ...provider, app });
   }
 
   if (options.apps && options.apps.length > 0) {
-    return options.apps.map((app) => builtIns.get(String(app)) || { app: String(app) });
+    return options.apps.map((app) => {
+      const canonical = canonicalApp(app);
+      return builtIns.get(canonical) || { app: canonical };
+    });
   }
 
   return Array.from(builtIns.values());
+}
+
+function canonicalApp(app: IconProvider['app']): string {
+  const appId = String(app);
+  return APP_ALIASES[appId] || appId;
 }
 
 function normalizeMaxAge(maxAgeMs: number | undefined): number {


### PR DESCRIPTION
## Summary
- align public app identifiers with `phonegap-launch-navigator` for Navigon, HERE Maps, MAPS.ME, and 99 Taxi while preserving legacy string aliases
- add Android `geo` chooser/discovery support so installed `geo:` apps such as Locus Map, Komoot, and OsmAnd can be surfaced by package name
- add missing iOS launch support for Navigon, Transit App, and 99 Taxi, plus Android 99 Taxi package/query support

Fixes #25

## Validation
- `bun run lint`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" bun run verify`